### PR TITLE
feat: Allow email login and remove ID length limit

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders the app title after loading', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const titleElement = await screen.findByText(/つくたん/i);
+  expect(titleElement).toBeInTheDocument();
 });

--- a/src/LoginPage.js
+++ b/src/LoginPage.js
@@ -11,8 +11,8 @@ function LoginPage() {
       alert('IDとパスワードを入力してください。');
       return;
     }
-    // 生徒IDからメールアドレスを生成
-    const email = `${studentId}@tsukasafoods.com`;
+    // If studentId contains '@', treat it as a full email. Otherwise, append domain.
+    const email = studentId.includes('@') ? studentId : `${studentId}@tsukasafoods.com`;
     try {
       await signInWithEmailAndPassword(auth, email, password);
     } catch (error) {
@@ -31,8 +31,7 @@ function LoginPage() {
             type="text"
             value={studentId}
             onChange={(e) => setStudentId(e.target.value)}
-            placeholder="4桁のID"
-            maxLength="4"
+            placeholder="IDまたはメールアドレス"
           />
         </div>
         <div className="input-group">

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,18 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock the firebase/auth module
+jest.mock('firebase/auth', () => ({
+  onAuthStateChanged: (auth, callback) => {
+    // Simulate a logged-out user immediately
+    callback(null);
+    // Return a mock unsubscribe function
+    return () => {};
+  },
+  signInWithEmailAndPassword: (auth, email, password) => {
+    // Mock a successful login
+    return Promise.resolve({
+      user: { uid: 'test-uid', email: email },
+    });
+  },
+  getAuth: () => ({}),
+}));


### PR DESCRIPTION
Modified the login page to support administrator login using a full email address.

- Removed the 4-character `maxLength` restriction from the ID input field.
- Updated the login handler to check if the input contains an "@" symbol. If so, it's treated as a full email address for authentication. Otherwise, the default domain is appended for student logins.
- Updated the ID field's placeholder text to "IDまたはメールアドレス" to reflect the new capability.
- Added a mock `firebaseConfig.js` for the test environment.
- Fixed the test suite by adding mocks for Firebase auth in `setupTests.js` and updating the main app test to be asynchronous, ensuring it passes correctly.