### PR TITLE
fix: 単語帳モードで読み上げが鳴らない問題を修正

### DIFF
--- a/src/LearningFlashcard.js
+++ b/src/LearningFlashcard.js
@@ -75,6 +75,12 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
 
   // 赤シート機能のハンドラー
   const handleRevealStart = (cardIndex) => {
+    if (revealedCards.has(cardIndex)) return;
+    // 意味が見えるのと同時に読み上げる。
+    // 「答えを見る」ボタンの onClick に置くと鳴らない。カード面の
+    // onMouseDown が先に走ってボタンが外れ、click まで到達しないため。
+    const word = shuffledWords[cardIndex];
+    if (word) speakWordThenMeaning(word.word, word.meaning);
     setRevealedCards(prev => new Set([...prev, cardIndex]));
   };
 
@@ -875,11 +881,7 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
                     <button
                       type="button"
                       className="wordbook-veil"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleRevealStart(actualIndex);
-                        speakWordThenMeaning(word.word, word.meaning);
-                      }}
+                      onClick={(e) => { e.stopPropagation(); handleRevealStart(actualIndex); }}
                       aria-label={`${word.word} の答えを見る`}
                     >
                       答えを見る

--- a/src/logic/speechUtils.js
+++ b/src/logic/speechUtils.js
@@ -2,6 +2,8 @@ import logger from './logger';
 const synthesis = window.speechSynthesis;
 let voices = [];
 let initializationPromise = null;
+// 発話中の utterance。GC で読み上げが切れるのを防ぐために保持する。
+let activeUtterance = null;
 
 const initialize = () => {
   if (initializationPromise) {
@@ -199,18 +201,31 @@ const speakSequence = (items) => {
   const queue = (items || []).filter((item) => item && item.text);
   if (queue.length === 0) return;
 
-  // 前の読み上げは打ち切る。カードを次々めくったときに溜まらないように。
-  synthesis.cancel();
-
   const speakAt = (index) => {
     if (index >= queue.length) return;
     const { text, lang = 'en-US' } = queue[index];
     const utterance = buildUtterance(text, lang);
-    utterance.onend = () => speakAt(index + 1);
+    // Chrome は発話中の utterance がGCされると途中で切れる。参照を残しておく。
+    activeUtterance = utterance;
+    utterance.onend = () => {
+      if (activeUtterance === utterance) activeUtterance = null;
+      speakAt(index + 1);
+    };
     // 読み上げに失敗しても次へ進める（音声が無い端末で止まらないように）
-    utterance.onerror = () => speakAt(index + 1);
+    utterance.onerror = () => {
+      if (activeUtterance === utterance) activeUtterance = null;
+      speakAt(index + 1);
+    };
     synthesis.speak(utterance);
   };
+
+  if (synthesis.speaking || synthesis.pending) {
+    // 前の読み上げは打ち切る。カードを次々めくったときに溜まらないように。
+    synthesis.cancel();
+    // cancel() の直後に speak() を呼ぶと Chrome が無視することがあるので間を置く。
+    setTimeout(() => speakAt(0), 100);
+    return;
+  }
 
   speakAt(0);
 };


### PR DESCRIPTION
## 問題

単語帳モードの「答えを見る」を押しても音声が一度も鳴っていなかった。

カード面の `onMouseDown` が先に発火して `handleRevealStart` が走り、その時点で「答えを見る」ボタンが DOM から外れる。結果 mouseup が届かず、音声を呼んでいたボタンの `onClick` が実行されない。

## 修正

読み上げを `handleRevealStart` に移し、ボタン・カード面・キーボードのどの経路から開いても鳴るようにした。

あわせて Chrome 固有の2点:
- `cancel()` 直後の `speak()` は無視されることがあるため、読み上げ中のときだけ cancel して 100ms 置いてから開始
- 発話中の utterance が GC されると途中で切れるため参照を保持

## 検証

本番で `speechSynthesis.speak` をフックして実測。

```
sanction  en-US  Google US English
制裁       ja-JP  Google 日本語
```

英語→日本語の順で、それぞれ適切な音声が選ばれることを確認した。テスト154件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)