### PR TITLE
style: 単語帳カードの余白を詰めて一覧性を上げる

### DIFF
--- a/src/components/learning/SessionHeader.css
+++ b/src/components/learning/SessionHeader.css
@@ -94,12 +94,12 @@
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
-  padding: calc(var(--space-16) * var(--wordbook-zoom, 1)) var(--space-16);
+  padding: calc(var(--space-8) * var(--wordbook-zoom, 1)) var(--space-12);
 }
 
 .wordbook-list__grid {
   display: grid;
-  gap: calc(var(--space-16) * var(--wordbook-zoom, 1));
+  gap: calc(var(--space-8) * var(--wordbook-zoom, 1));
 }
 
 .wordbook-card {
@@ -118,14 +118,14 @@
 .wordbook-card__grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  min-height: calc(120px * var(--wordbook-zoom, 1));
+  min-height: calc(72px * var(--wordbook-zoom, 1));
 }
 
 .wordbook-card__side {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: calc(var(--space-24) * var(--wordbook-zoom, 1));
+  padding: calc(var(--space-12) * var(--wordbook-zoom, 1)) calc(var(--space-16) * var(--wordbook-zoom, 1));
 }
 
 .wordbook-card__left {
@@ -140,18 +140,18 @@
 }
 
 .wordbook-index {
-  margin-top: var(--space-4);
+  margin-top: var(--space-2);
   font-size: calc(var(--font-size-12) * var(--wordbook-zoom, 1));
   color: var(--color-olive-muted);
 }
 
 @media (max-width: 767px) {
   .wordbook-card__grid {
-    min-height: calc(80px * var(--wordbook-zoom, 1));
+    min-height: calc(56px * var(--wordbook-zoom, 1));
   }
 
   .wordbook-card__side {
-    padding: calc(var(--space-12) * var(--wordbook-zoom, 1));
+    padding: calc(var(--space-8) * var(--wordbook-zoom, 1)) calc(var(--space-12) * var(--wordbook-zoom, 1));
   }
 }
 
@@ -265,8 +265,8 @@
   font-size: calc(var(--font-size-22) * var(--wordbook-zoom, 1));
   font-weight: 700;
   color: var(--color-ink-olive);
-  line-height: 1.25;
-  margin-bottom: var(--space-4);
+  line-height: 1.2;
+  margin-bottom: var(--space-2);
   overflow-wrap: anywhere;
 }
 
@@ -280,8 +280,8 @@
   font-size: calc(var(--font-size-16) * var(--wordbook-zoom, 1));
   font-weight: 600;
   color: var(--color-ink-olive);
-  line-height: 1.4;
-  margin-bottom: var(--space-8);
+  line-height: 1.35;
+  margin-bottom: var(--space-4);
   overflow-wrap: anywhere;
 }
 
@@ -289,8 +289,8 @@
   font-size: calc(var(--font-size-14) * var(--wordbook-zoom, 1));
   color: var(--color-olive-muted);
   font-style: italic;
-  line-height: 1.4;
-  margin-bottom: var(--space-4);
+  line-height: 1.35;
+  margin-bottom: var(--space-2);
 }
 
 .wordbook-example__ja {


### PR DESCRIPTION
同じ倍率で1画面に入る語数を 6 → 8.5 に増やす（最小30%なら14語）。

- カード内の余白 24px → 縦12 / 横16px（スマホは 12 → 縦8 / 横12）
- カード間の間隔 16px → 8px
- 一覧の外周 16px → 縦8 / 横12px
- カードの最小高さ 120px → 72px（スマホ 80 → 56）
- 語・意味・例文の行間と下余白を詰める

いずれも `--wordbook-zoom` に連動したままなのでスライダーの効きは変わらない。本番で表示確認済み、テスト154件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)