### PR TITLE
style: 単語帳の文字をカードいっぱいまで大きくする

### DIFF
--- a/src/components/learning/SessionHeader.css
+++ b/src/components/learning/SessionHeader.css
@@ -131,6 +131,8 @@
 .wordbook-card__left {
   border-right: var(--border-default);
   background-color: var(--color-surface);
+  /* 語の大きさを列幅で頭打ちにするため、この列をコンテナにする */
+  container-type: inline-size;
 }
 
 .wordbook-card__right {
@@ -141,7 +143,7 @@
 
 .wordbook-index {
   margin-top: var(--space-2);
-  font-size: calc(var(--font-size-12) * var(--wordbook-zoom, 1));
+  font-size: max(9px, calc(var(--font-size-12) * var(--wordbook-zoom, 1)));
   color: var(--color-olive-muted);
 }
 
@@ -169,7 +171,7 @@
   background-color: rgba(220, 38, 38, 0.85);
   color: var(--color-surface);
   font-family: var(--font-family-body);
-  font-size: calc(var(--font-size-16) * var(--wordbook-zoom, 1));
+  font-size: max(12px, calc(var(--font-size-16) * var(--wordbook-zoom, 1) * 1.2));
   font-weight: 700;
   cursor: pointer;
 }
@@ -262,7 +264,9 @@
   background: none;
   text-align: left;
   cursor: pointer;
-  font-size: calc(var(--font-size-22) * var(--wordbook-zoom, 1));
+  /* 倍率で伸ばしつつ、列幅(18cqi)と下限(15px)で挟む。
+     縮めたときも読める大きさを保ち、長い語は列からはみ出させない。 */
+  font-size: clamp(15px, calc(var(--font-size-22) * var(--wordbook-zoom, 1) * 1.5), 18cqi);
   font-weight: 700;
   color: var(--color-ink-olive);
   line-height: 1.2;
@@ -271,13 +275,13 @@
 }
 
 .wordbook-pronunciation {
-  font-size: calc(var(--font-size-14) * var(--wordbook-zoom, 1));
+  font-size: max(11px, calc(var(--font-size-14) * var(--wordbook-zoom, 1) * 1.3));
   color: var(--color-olive-muted);
   font-style: italic;
 }
 
 .wordbook-meaning {
-  font-size: calc(var(--font-size-16) * var(--wordbook-zoom, 1));
+  font-size: max(13px, calc(var(--font-size-16) * var(--wordbook-zoom, 1) * 1.4));
   font-weight: 600;
   color: var(--color-ink-olive);
   line-height: 1.35;
@@ -286,7 +290,7 @@
 }
 
 .wordbook-example__en {
-  font-size: calc(var(--font-size-14) * var(--wordbook-zoom, 1));
+  font-size: max(11px, calc(var(--font-size-14) * var(--wordbook-zoom, 1) * 1.25));
   color: var(--color-olive-muted);
   font-style: italic;
   line-height: 1.35;
@@ -294,7 +298,7 @@
 }
 
 .wordbook-example__ja {
-  font-size: calc(var(--font-size-12) * var(--wordbook-zoom, 1));
+  font-size: max(10px, calc(var(--font-size-12) * var(--wordbook-zoom, 1) * 1.25));
   color: var(--color-olive-muted);
   line-height: 1.4;
 }


### PR DESCRIPTION
倍率を下げるとカードの余白ばかり詰まり、文字が小さすぎてカードの中がスカスカだった（最小30%で語が6.6px）。

- 語は `clamp(15px, 倍率 * 1.5, 18cqi)`。左の列を container にして列幅の18%を上限にする。長い語は折り返して収まり、はみ出さない
- 意味・例文・発音記号・赤シートの文字にも下限と 1.25〜1.4 倍の増幅

本番で実測: 最小30%で語 15px、110%で 31.3px（列幅209pxの上限に張り付き）。はみ出しなし。テスト154件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)