### PR TITLE
style: 単語帳の語をカードの高さいっぱいに、連番を削除

### DIFF
--- a/src/LearningFlashcard.js
+++ b/src/LearningFlashcard.js
@@ -14,7 +14,7 @@ import { usePronunciation } from './logic/usePronunciation';
 
 // 単語帳モードの文字サイズの下限・上限（%）。一覧で見渡したいときは小さく、
 // 1語ずつ確かめたいときは大きくできるよう幅を広めに取る。
-const MIN_ZOOM = 30;
+const MIN_ZOOM = 20;
 const MAX_ZOOM = 200;
 
 // 配列をシャッフルするヘルパー関数
@@ -839,9 +839,6 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
                       [{word.pronunciation || getPronunciation(word.word)}]
                     </div>
                   )}
-                  <div className="wordbook-index">
-                    {index + 1} / {shuffledWords.length}
-                  </div>
                 </div>
 
                 {/* 右側：和訳・例文（赤シート機能付き + 復習モード長押し機能） */}

--- a/src/components/learning/SessionHeader.css
+++ b/src/components/learning/SessionHeader.css
@@ -118,21 +118,23 @@
 .wordbook-card__grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  min-height: calc(72px * var(--wordbook-zoom, 1));
+  min-height: calc(40px * var(--wordbook-zoom, 1));
 }
 
 .wordbook-card__side {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: calc(var(--space-12) * var(--wordbook-zoom, 1)) calc(var(--space-16) * var(--wordbook-zoom, 1));
+  padding: calc(var(--space-8) * var(--wordbook-zoom, 1)) calc(var(--space-12) * var(--wordbook-zoom, 1));
 }
 
 .wordbook-card__left {
   border-right: var(--border-default);
   background-color: var(--color-surface);
-  /* 語の大きさを列幅で頭打ちにするため、この列をコンテナにする */
-  container-type: inline-size;
+  /* この列をコンテナにして、語の大きさを列の幅と高さの両方から決める。
+     size 指定なので列の中身は高さに影響しない。行の高さは右側（意味・
+     例文）と min-height で決まるため、循環しない。 */
+  container-type: size;
 }
 
 .wordbook-card__right {
@@ -141,19 +143,13 @@
   user-select: none;
 }
 
-.wordbook-index {
-  margin-top: var(--space-2);
-  font-size: max(9px, calc(var(--font-size-12) * var(--wordbook-zoom, 1)));
-  color: var(--color-olive-muted);
-}
-
 @media (max-width: 767px) {
   .wordbook-card__grid {
-    min-height: calc(56px * var(--wordbook-zoom, 1));
+    min-height: calc(32px * var(--wordbook-zoom, 1));
   }
 
   .wordbook-card__side {
-    padding: calc(var(--space-8) * var(--wordbook-zoom, 1)) calc(var(--space-12) * var(--wordbook-zoom, 1));
+    padding: calc(var(--space-4) * var(--wordbook-zoom, 1)) calc(var(--space-8) * var(--wordbook-zoom, 1));
   }
 }
 
@@ -171,7 +167,7 @@
   background-color: rgba(220, 38, 38, 0.85);
   color: var(--color-surface);
   font-family: var(--font-family-body);
-  font-size: max(12px, calc(var(--font-size-16) * var(--wordbook-zoom, 1) * 1.2));
+  font-size: max(9px, calc(var(--font-size-16) * var(--wordbook-zoom, 1) * 1.2));
   font-weight: 700;
   cursor: pointer;
 }
@@ -266,7 +262,9 @@
   cursor: pointer;
   /* 倍率で伸ばしつつ、列幅(18cqi)と下限(15px)で挟む。
      縮めたときも読める大きさを保ち、長い語は列からはみ出させない。 */
-  font-size: clamp(15px, calc(var(--font-size-22) * var(--wordbook-zoom, 1) * 1.5), 18cqi);
+  /* カードの高さを使い切る。幅(20cqi)と高さ(46cqh)の小さい方まで伸ばす。
+     カードの高さ自体が倍率に連動するので、スライダーはそのまま効く。 */
+  font-size: clamp(8px, min(20cqi, 46cqh), 40px);
   font-weight: 700;
   color: var(--color-ink-olive);
   line-height: 1.2;
@@ -275,13 +273,13 @@
 }
 
 .wordbook-pronunciation {
-  font-size: max(11px, calc(var(--font-size-14) * var(--wordbook-zoom, 1) * 1.3));
+  font-size: clamp(7px, min(13cqi, 28cqh), 22px);
   color: var(--color-olive-muted);
   font-style: italic;
 }
 
 .wordbook-meaning {
-  font-size: max(13px, calc(var(--font-size-16) * var(--wordbook-zoom, 1) * 1.4));
+  font-size: max(8px, calc(var(--font-size-16) * var(--wordbook-zoom, 1) * 1.5));
   font-weight: 600;
   color: var(--color-ink-olive);
   line-height: 1.35;
@@ -290,7 +288,7 @@
 }
 
 .wordbook-example__en {
-  font-size: max(11px, calc(var(--font-size-14) * var(--wordbook-zoom, 1) * 1.25));
+  font-size: max(7px, calc(var(--font-size-14) * var(--wordbook-zoom, 1) * 1.25));
   color: var(--color-olive-muted);
   font-style: italic;
   line-height: 1.35;
@@ -298,7 +296,7 @@
 }
 
 .wordbook-example__ja {
-  font-size: max(10px, calc(var(--font-size-12) * var(--wordbook-zoom, 1) * 1.25));
+  font-size: max(7px, calc(var(--font-size-12) * var(--wordbook-zoom, 1) * 1.25));
   color: var(--color-olive-muted);
   line-height: 1.4;
 }


### PR DESCRIPTION
カード41pxに対して左側の中身が21pxしかなく、17px分が死んでいた。カードの高さは右側（意味・例文）が決めるので、語をその高さに連動させる。

- 左の列を `container-type: size` にして、語を `min(20cqi, 46cqh)` で幅と高さの両方から決める。size 指定なので列の中身は行の高さに影響せず、循環しない。長い語は幅側の上限で縮み、はみ出さない
- 最小20%で語 8px → 16.6px、左側の中身39px / カード41px に
- 「1 / 20」の連番を削除
- 縮小の下限を 30% → 20%
- カードの最小高さ 72 → 40px、内側の余白 縦12 → 8px

本番で実測して確認。テスト154件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)