### PR TITLE
fix: 収録0語の教材を自由学習の一覧に出さない

### DIFF
--- a/src/StudentDashboard.js
+++ b/src/StudentDashboard.js
@@ -199,8 +199,7 @@ const isRecommendedTextbook = (textbookId, testLevel, userData) => {
     'eiken-3': { min: 3, max: 4 },
     'eiken-pre2': { min: 4, max: 5 },
     'eiken-2': { min: 5, max: 6 },
-    'eiken-pre1': { min: 6, max: 7 },
-    'eiken-1': { min: 7, max: 8 }
+    'eiken-pre1': { min: 6, max: 7 }
   };
   
   const mapping = textbookLevelMapping[textbookId];
@@ -337,8 +336,9 @@ const freeStudyOptions = [
   { id: 'eiken-3', label: '英検3級', textbooks: ['highschool-english'] },
   { id: 'eiken-pre2', label: '英検準2級', textbooks: ['highschool-english'] },
   { id: 'eiken-2', label: '英検2級', textbooks: ['highschool-english'] },
-  { id: 'eiken-pre1', label: '英検準1級', textbooks: ['highschool-english'] },
-  { id: 'eiken-1', label: '英検1級', textbooks: ['highschool-english'] }
+  { id: 'eiken-pre1', label: '英検準1級', textbooks: ['highschool-english'] }
+  // 英検1級は置かない。実データに eikenLevels: 1 の単語が1語も無く、
+  // 常に「0語」のカードになる（src/config/levels.json も準1級まで）。
 ];
 // 通常のレベル定義（実際のデータに基づいて調整）
 // レベルの対応表は src/config/levels.json が正本。ここでは表示形に変換するだけ。
@@ -1887,7 +1887,12 @@ export default function StudentDashboard() {
               const priority = recommendationType ? recommendationType.priority : 'medium';
               
               const wordCount = getTextbookWordCount(id, masterWords, textbookCounts);
-              
+
+              // 収録が0語の教材は出さない。選んでも何も学べない。
+              // 単語データの読み込み前（masterWords が空）は判定できないので、
+              // そのときは出したままにする。
+              if (masterWords.length > 0 && wordCount === 0) return null;
+
               return (
                 <button key={id} className="tile-button" onClick={() => {
                   logger.debug('🎯 教材選択ボタンクリック:', { id, label, isRecommended, wordCount });

--- a/src/config/config.test.js
+++ b/src/config/config.test.js
@@ -247,3 +247,21 @@ describe('発音記号', () => {
     expect(inconsistent.map(([word]) => word)).toEqual([]);
   });
 });
+
+describe('自由学習の教材', () => {
+  const master = require('../../public/data/words-master.json');
+
+  test('英検1級の単語は実データに存在しない', () => {
+    // 教材一覧に英検1級を置くと、常に「0語」のカードになる
+    const hasEiken1 = master.some((word) => (word.eikenLevels || []).includes(1));
+    expect(hasEiken1).toBe(false);
+  });
+
+  test('準1級までは実データに単語がある', () => {
+    for (const level of [5, 4, 3, 'pre2', 2, 'pre1']) {
+      const count = master.filter((word) => (word.eikenLevels || []).includes(level)).length;
+      expect({ level, count }).toEqual({ level, count: expect.any(Number) });
+      expect(count).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
「英検1級 0語」が推奨バッジ付きで並んでいた。選んでも何も学べない。

- 英検1級の教材そのものを外す。実データに `eikenLevels: 1` の単語は1語も無く、`src/config/levels.json` も準1級までしか置いていない。推奨判定の対応表からも削除
- あわせて、収録0語の教材は一覧に出さないようにした。データが変わって空になった教材にも効く。単語データの読み込み前は判定できないので、そのときは出したままにする
- 実データの検証テストを2件追加

本番確認: 残る8教材はすべて単語あり（大阪3193 / 高校英語5894 / 5級406 / 4級612 / 3級1041 / 準2級1787 / 2級2338 / 準1級3484）。テスト191件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)