### PR TITLE
fix: 学習ロジックの沈黙失敗を4件直す（移行なし）

### DIFF
--- a/src/LearningFlashcard.js
+++ b/src/LearningFlashcard.js
@@ -180,6 +180,9 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
   const { isBookmarked, toggle: toggleBookmark } = useBookmarks(auth.currentUser?.uid);
   // 先頭へ戻るのスクロール対象。スクロールするのは画面ではなくこの要素。
   const wordbookShellRef = useRef(null);
+  // このセッションで初めて記録した単語のID。習得語数はここから数える。
+  // 画面のインデックス数だと、戻る・再回答で二重に数えてしまう。
+  const newlyLearnedIdsRef = useRef(new Set());
   const currentWord = shuffledWords?.[currentIndex];
 
   const handleBackButtonClick = useCallback(() => {
@@ -200,7 +203,7 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
     }
     
     // 親コンポーネントの戻る処理を呼び出し
-    onBack(incorrectWords);
+    onBack(incorrectWords, newlyLearnedIdsRef.current.size);
   }, [currentIndex, shuffledWords, sessionInfo, onSaveLog, incorrectWords, onBack]);
 
 
@@ -235,7 +238,11 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
     const user = auth.currentUser;
     
     if (user && currentWord) {
-      trackWrite(updateUserWordProgress(user.uid, currentWord, quality));
+      trackWrite(
+        updateUserWordProgress(user.uid, currentWord, quality).then((result) => {
+          if (result?.created) newlyLearnedIdsRef.current.add(currentWord.id);
+        })
+      );
     }
     
     // 次の単語へ
@@ -268,7 +275,7 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
       // 書き込みを取りこぼさないよう、画面を閉じる前に待つ
       await flushWrites();
       // 親コンポーネントの戻る処理を呼び出し
-      onBack(incorrectWords);
+      onBack(incorrectWords, newlyLearnedIdsRef.current.size);
     }
   }, [currentIndex, shuffledWords, x, y, hasCompletedOnce, onFirstCompletion, sessionInfo, onSaveLog, incorrectWords, onBack, trackWrite, flushWrites, auth.currentUser]);
 
@@ -282,7 +289,11 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
     // 不正解の場合、復習リストに追加
     if (currentWord) {
       if (user) {
-        trackWrite(updateUserWordProgress(user.uid, currentWord, 'again'));
+        trackWrite(
+          updateUserWordProgress(user.uid, currentWord, 'again').then((result) => {
+            if (result?.created) newlyLearnedIdsRef.current.add(currentWord.id);
+          })
+        );
       }
       setIncorrectWords(prev => [...prev.filter(w => w.id !== currentWord.id), currentWord]);
     }
@@ -317,7 +328,7 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
       // 書き込みを取りこぼさないよう、画面を閉じる前に待つ
       await flushWrites();
       // 親コンポーネントの戻る処理を呼び出し
-      onBack(incorrectWords);
+      onBack(incorrectWords, newlyLearnedIdsRef.current.size);
     }
   }, [currentIndex, shuffledWords, x, y, hasCompletedOnce, onFirstCompletion, sessionInfo, onSaveLog, incorrectWords, onBack, trackWrite, flushWrites, auth.currentUser]);
 
@@ -990,7 +1001,7 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
         title={title || (isReviewMode ? '復習単語' : '新規学習')}
         current={currentIndex + 1}
         total={shuffledWords.length}
-        onBack={() => onBack(incorrectWords)}
+        onBack={() => onBack(incorrectWords, newlyLearnedIdsRef.current.size)}
         backLabel="終了"
         actions={(
           <>

--- a/src/StudentDashboard.js
+++ b/src/StudentDashboard.js
@@ -4,7 +4,6 @@ import { auth, db } from './firebaseConfig';
 import './Analytics.css';
 import { collection, getDocs, doc, getDoc, setDoc, query, orderBy, updateDoc, increment, where } from "firebase/firestore";
 import { generateDailyPlan } from './logic/learningPlanner';
-import { addWordToReview } from './logic/reviewLogic';
 import { updateProgressPercentage } from './logic/progressLogic';
 import { logStudySession } from './logic/studyLogger';
 import { saveFreeStudyProgress, getFreeStudyProgress, getAllFreeStudyProgress } from './logic/freeStudyProgress';
@@ -827,11 +826,9 @@ export default function StudentDashboard() {
     const user = auth.currentUser;
     if (!user) return;
 
-    // Handle incorrect words
-    if (incorrectWords && incorrectWords.length > 0) {
-      // forEach で投げっぱなしにすると、画面遷移で書き込みを取りこぼす（計画書10.2.10）
-      await Promise.all(incorrectWords.map(word => addWordToReview(user.uid, word)));
-    }
+    // 不正解単語はここでは登録しない。LearningFlashcard が回答のたびに
+    // updateUserWordProgress('again') で記録済み。ここでも addWordToReview を
+    // 呼ぶと、積み上げた復習間隔を初期値へ上書きしてしまう。
 
     // Update vocabulary count and progress if new words were learned
     if (newlyLearnedCount > 0) {
@@ -1575,7 +1572,13 @@ export default function StudentDashboard() {
                   sessionInfo={currentSessionInfo}
                 />;
       case 'test':
-        return <VocabularyCheckTest allWords={testWords} onTestComplete={handleTestComplete} />;
+        return (
+          <VocabularyCheckTest
+            allWords={testWords}
+            onTestComplete={handleTestComplete}
+            onCancel={() => setViewMode('select')}
+          />
+        );
       case 'result':
         const lastResponseTimes = JSON.parse(localStorage.getItem('lastTestResponseTimes') || '[]');
         return <TestResult level={testResultLevel} onRestart={() => {}} responseTimes={lastResponseTimes} />;

--- a/src/VocabularyCheckTest.js
+++ b/src/VocabularyCheckTest.js
@@ -10,6 +10,7 @@ import { updateProgressPercentage } from './logic/progressLogic';
 import { FaUndo, FaArrowLeft } from 'react-icons/fa';
 import {
   MAX_STAGES,
+  MIN_ANSWERS_FOR_EARLY_FINISH,
   createInitialState,
   selectQuestions,
   recordAnswer,
@@ -29,7 +30,7 @@ import {
  * 難易度が動くのはステージを締めたときだけなので、5問目で調整が入っても
  * ステージが作り直されることはない。
  */
-export default function VocabularyCheckTest({ allWords: passedWords, onTestComplete }) {
+export default function VocabularyCheckTest({ allWords: passedWords, onTestComplete, onCancel }) {
   const navigate = useNavigate();
 
   // 単語は呼び出し元が渡す。ここで巨大なJSONを import しない（計画書13.5）。
@@ -44,6 +45,8 @@ export default function VocabularyCheckTest({ allWords: passedWords, onTestCompl
   const [isFlipped, setIsFlipped] = useState(false);
   const [questionStartTime, setQuestionStartTime] = useState(null);
   const [saveError, setSaveError] = useState(null);
+  // 回答が少ないまま抜けようとしたときの確認
+  const [confirmLeave, setConfirmLeave] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
   const x = useMotionValue(0);
@@ -190,13 +193,57 @@ export default function VocabularyCheckTest({ allWords: passedWords, onTestCompl
   };
 
   const handleLeave = async () => {
-    // 途中で抜けるときも、それまでの回答からレベルを出して保存する
-    if (engine.allAnswers.length > 0) {
+    // 回答が少ないうちに抜けた結果でレベルを上書きしない。
+    // 1問だけ答えて戻ると、そのレベルが正式なレベルとして保存され、
+    // 日次計画・推薦・進捗のすべてが狂っていた。
+    // MIN_ANSWERS_FOR_EARLY_FINISH はエンジン側の早期終了の下限と同じ。
+    if (engine.allAnswers.length >= MIN_ANSWERS_FOR_EARLY_FINISH) {
       await finishTestAndSave({ ...engine, resultLevel: computeResultLevel(engine) });
       return;
     }
-    navigate('/student-dashboard');
+    if (engine.allAnswers.length > 0) {
+      setConfirmLeave(true);
+      return;
+    }
+    leaveWithoutSaving();
   };
+
+  // テストは画面内のモード切替で表示している。ルートではないため
+  // navigate('/student-dashboard') では抜けられない（押しても何も起きなかった）。
+  // 親から渡された戻り方を使う。
+  const leaveWithoutSaving = () => {
+    if (onCancel) onCancel();
+    else navigate('/student-dashboard');
+  };
+
+  if (confirmLeave) {
+    return (
+      <div className="loading-container">
+        <div className="app-status-card">
+          <h1 className="app-status-title">結果は保存されません</h1>
+          <p className="app-status-message">
+            レベルを判定するには {MIN_ANSWERS_FOR_EARLY_FINISH} 問以上の回答が必要です。
+            （今 {engine.allAnswers.length} 問）
+            ここでやめると、今のレベルはそのままになります。
+          </p>
+          <button
+            type="button"
+            className="primary-action"
+            onClick={() => setConfirmLeave(false)}
+          >
+            テストを続ける
+          </button>
+          <button
+            type="button"
+            className="ghost-button"
+            onClick={leaveWithoutSaving}
+          >
+            結果を破棄して戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   if (saveError) {
     return (

--- a/src/logic/reviewLogic.js
+++ b/src/logic/reviewLogic.js
@@ -56,28 +56,27 @@ export const addWordToReview = async (userId, word) => {
  * @param {string} motivationLevel やる気レベル
  */
 export const updateUserWordProgress = async (userId, word, answer, isReviewComplete = false, motivationLevel = 'normal') => {
-  if (!userId || !word || !word.id) return;
+  if (!userId || !word || !word.id) return { created: false, mastered: false };
 
   const reviewWordRef = doc(db, 'users', userId, 'reviewWords', word.id);
 
   try {
     const docSnap = await getDoc(reviewWordRef);
-    let wordData;
+    const isFirstTime = !docSnap.exists();
 
-    if (docSnap.exists()) {
-      wordData = docSnap.data();
-    } else {
-      // もし何らかの理由で復習リストにない単語が来た場合、新規追加の処理を行う
-      await addWordToReview(userId, word);
-      return;
-    }
+    // 初めて出会う単語も、その回答を反映して状態を作る。
+    // 以前はここで addWordToReview して return しており、正解しても
+    // 不正解しても同じ状態（interval:1 / repetitions:0）になっていた。
+    const wordData = isFirstTime
+      ? { ...word, interval: 0, repetitions: 0, easeFactor: 2.5, firstSeenAt: new Date() }
+      : docSnap.data();
 
     const today = new Date();
     today.setHours(0, 0, 0, 0); // 時間を正規化
     // 復習完了の場合は、完全に復習リストから除去
     if (isReviewComplete) {
       await removeWordFromReview(userId, word.id);
-      return;
+      return { created: false, mastered: true };
     }
 
     const config = MOTIVATION_LEVELS[motivationLevel] || MOTIVATION_LEVELS.normal;
@@ -113,8 +112,11 @@ export const updateUserWordProgress = async (userId, word, answer, isReviewCompl
       easeFactor: easeFactor,
     });
 
+    // 初めて記録した単語かどうかを返す。呼び出し側が習得語数を数える。
+    return { created: isFirstTime, mastered: false };
   } catch (error) {
     console.error('単語の進捗更新に失敗しました:', error);
+    return { created: false, mastered: false, error };
   }
 };
 

--- a/src/logic/reviewScheduling.test.js
+++ b/src/logic/reviewScheduling.test.js
@@ -113,3 +113,34 @@ describe('shouldRepeatToday / actionForQuality', () => {
     expect(actionForQuality(ANSWER_QUALITY.again)).toBe('incorrect');
   });
 });
+
+describe('初見の単語（進捗が無い状態からの1回答目）', () => {
+  // reviewLogic は初回に { interval: 0, repetitions: 0, easeFactor: 2.5 } を作って
+  // そこへ回答を適用する。以前は回答を捨てて必ず interval:1 / repetitions:0 に
+  // していたため、正解でも不正解でも同じ状態になっていた。
+  const fresh = { interval: 0, repetitions: 0, easeFactor: 2.5 };
+
+  test('正解と不正解で状態が変わる', () => {
+    const good = nextSchedule(fresh, ANSWER_QUALITY.good, normal);
+    const again = nextSchedule(fresh, ANSWER_QUALITY.again, normal);
+    expect(good).not.toEqual(again);
+  });
+
+  test('初回正解は翌日、繰り返し1回目になる', () => {
+    const next = nextSchedule(fresh, ANSWER_QUALITY.good, normal);
+    expect(next.interval).toBe(1);
+    expect(next.repetitions).toBe(1);
+  });
+
+  test('初回不正解は当日のまま、繰り返しは進まない', () => {
+    const next = nextSchedule(fresh, ANSWER_QUALITY.again, normal);
+    expect(next.interval).toBe(0);
+    expect(next.repetitions).toBe(0);
+    expect(shouldRepeatToday(ANSWER_QUALITY.again)).toBe(true);
+  });
+
+  test('初回不正解のほうが Ease Factor が低い', () => {
+    expect(nextSchedule(fresh, ANSWER_QUALITY.again, normal).easeFactor)
+      .toBeLessThan(nextSchedule(fresh, ANSWER_QUALITY.good, normal).easeFactor);
+  });
+});


### PR DESCRIPTION
`LEARNING_LOGIC_FIX_PLAN.md` の指摘のうち、データ移行を伴わずに直せるものを先に対応。いずれもコードで再現を確認済み。

### 1. 習得語彙数が一度も増えていなかった

`LearningFlashcard` の `onBack` は4箇所すべて1引数呼び出しで、受け側 `handleLearningBack(incorrectWords, newlyLearnedCount)` の第2引数が常に `undefined`。`if (newlyLearnedCount > 0)` が真にならず `progress.currentVocabulary` が更新されていなかった。初めて記録した単語のIDを Set に集めて渡す。

### 2. 初見単語の正解と不正解が同じ状態になっていた

`updateUserWordProgress` が進捗の無い単語を `addWordToReview` して `return` し、回答結果を捨てていた。正解でも不正解でも `interval:1 / repetitions:0`。初期状態を作ってから回答を適用する。

### 3. 実力テストの途中終了が正式レベルを上書きしていた

1問答えて戻るだけでそのレベルが保存され、日次計画・推薦・進捗へ波及していた。エンジンに `MIN_ANSWERS_FOR_EARLY_FINISH(15)` があったのに離脱経路で使われていなかった。

### 4. 不正解単語の二重登録

`LearningFlashcard` が回答ごとに記録しているのに `StudentDashboard` でも `addWordToReview` を呼び、積み上げた復習間隔を初期値へ上書きしていた。

### 副次的な修正

テストは画面内のモード切替で表示しており `navigate('/student-dashboard')` では抜けられなかった（押しても何も起きない）。`onCancel` を親から渡す。

### 検証

本番実測: 新規学習2語で語彙数 **7,949 → 7,950**（既存語は数えない）。1問で離脱してもレベル7のまま。テスト195件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)