### PR TITLE
fix: 学習ロジック計画の残り3件（EF発散・日次計画の固定・習得履歴の保持）

### DIFF
--- a/src/AdminDashboard.js
+++ b/src/AdminDashboard.js
@@ -444,7 +444,8 @@ function AdminDashboard() {
       // 生徒側の日次プランと同じ条件で除外する。
       const reviewWords = reviewWordsSnapshot.docs
         .map(d => ({ ...d.data(), id: d.id }))
-        .filter(word => !word.migratedTo);
+        // 習得済みは復習リストの件数には数えない（履歴として残しているだけ）
+        .filter(word => !word.migratedTo && word.status !== 'mastered');
 
       // 生徒側と Functions は generatedStories に書く。
       // ここが 'stories' を読んでいたため、管理画面ではストーリーが常に空だった。

--- a/src/LearningFlashcard.js
+++ b/src/LearningFlashcard.js
@@ -27,7 +27,11 @@ const shuffleArray = (array) => {
   return newArray;
 };
 
-export default function LearningFlashcard({ words, onBack, initialIndex = 0, sessionInfo, onSaveLog, onFirstCompletion, title }) {
+export default function LearningFlashcard({
+  words, onBack, initialIndex = 0, sessionInfo, onSaveLog, onFirstCompletion, title,
+  // 日次学習のときだけ渡る。1語ずつ記録して、途中で閉じても再開できるようにする。
+  onWordAnswered,
+}) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [isFlipped, setIsFlipped] = useState(false);
   const [incorrectWords, setIncorrectWords] = useState([]);
@@ -183,6 +187,9 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
   // このセッションで初めて記録した単語のID。習得語数はここから数える。
   // 画面のインデックス数だと、戻る・再回答で二重に数えてしまう。
   const newlyLearnedIdsRef = useRef(new Set());
+  // 親から毎回新しい関数が来るので、依存に入れずに最新を参照する
+  const onWordAnsweredRef = useRef(onWordAnswered);
+  onWordAnsweredRef.current = onWordAnswered;
   const currentWord = shuffledWords?.[currentIndex];
 
   const handleBackButtonClick = useCallback(() => {
@@ -241,6 +248,7 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
       trackWrite(
         updateUserWordProgress(user.uid, currentWord, quality).then((result) => {
           if (result?.created) newlyLearnedIdsRef.current.add(currentWord.id);
+          onWordAnsweredRef.current?.(currentWord.id);
         })
       );
     }
@@ -292,6 +300,7 @@ export default function LearningFlashcard({ words, onBack, initialIndex = 0, ses
         trackWrite(
           updateUserWordProgress(user.uid, currentWord, 'again').then((result) => {
             if (result?.created) newlyLearnedIdsRef.current.add(currentWord.id);
+            onWordAnsweredRef.current?.(currentWord.id);
           })
         );
       }

--- a/src/StudentDashboard.js
+++ b/src/StudentDashboard.js
@@ -14,6 +14,7 @@ import { buildThemeGroups, themeLabels, themeDescriptions } from './logic/themeM
 import AnalyticsPanel from './components/student/AnalyticsPanel';
 import StoryPanel from './components/student/StoryPanel';
 import { useBookmarks } from './logic/useBookmarks';
+import { markNewWordAnswered } from './logic/dailyPlanRepository';
 import ReviewFlashcard from './ReviewFlashcard';
 import LevelBadge from './LevelBadge';
 import { FaBook, FaSyncAlt, FaMagic, FaStar } from 'react-icons/fa';
@@ -1563,6 +1564,11 @@ export default function StudentDashboard() {
                   sessionInfo={currentSessionInfo}
                   onFirstCompletion={currentLearningMode === 'daily' ? () => markDailyTaskAsCompleted(auth.currentUser.uid) : null}
                   title={currentLearningMode === 'bookmark' ? '毎日みる単語' : undefined}
+                  onWordAnswered={
+                    (currentLearningMode === 'daily' || currentLearningMode === 'extra') && dailyPlan.dateKey
+                      ? (wordId) => markNewWordAnswered(auth.currentUser?.uid, dailyPlan.dateKey, wordId)
+                      : undefined
+                  }
                 />;
       case 'review':
         return <ReviewFlashcard 

--- a/src/logic/dailyPlanRepository.js
+++ b/src/logic/dailyPlanRepository.js
@@ -1,0 +1,86 @@
+import { doc, getDoc, setDoc, updateDoc, arrayUnion } from 'firebase/firestore';
+import { db } from '../firebaseConfig';
+import logger from './logger';
+
+/**
+ * 日次計画の保存と読み出し。
+ *
+ * users/{uid}/dailyPlans/{YYYY-MM-DD}
+ *
+ * 以前は画面を開くたびに新規単語を抽選し直していた（getNewWords が
+ * Math.random でシャッフルする）。途中で抜けて戻ると別の単語が並び、
+ * 1日の新規語数も上限を超えて増えていた。
+ *
+ * 単語の中身も保存する。IDだけだと再開のたびに教材コレクションを
+ * 引き直すことになり、読み取りが増えるうえ、教材が差し替わると
+ * その日の計画が崩れる。
+ */
+
+/** 計画の形を変えたら上げる。上げると既存の計画は作り直される。 */
+export const PLAN_VERSION = 1;
+
+/**
+ * 計画を作り直すべきかを決める署名。
+ * 目標・達成日・やる気・レベルが変わったら、その日の計画も作り直す。
+ */
+export const planSignature = (userData) => [
+  (userData?.goal?.targets || []).map((t) => t?.goalId || t).sort().join(','),
+  userData?.goal?.targetDate || '',
+  userData?.goal?.motivationLevel || 'normal',
+  String(userData?.level ?? ''),
+].join('|');
+
+/** 保存済み計画がそのまま使えるか */
+export const isStoredPlanUsable = (stored, signature) =>
+  Boolean(stored)
+  && stored.planVersion === PLAN_VERSION
+  && stored.signature === signature
+  && Array.isArray(stored.newWords);
+
+export const loadDailyPlan = async (userId, dateKey) => {
+  if (!userId || !dateKey) return null;
+  try {
+    const snapshot = await getDoc(doc(db, 'users', userId, 'dailyPlans', dateKey));
+    return snapshot.exists() ? snapshot.data() : null;
+  } catch (error) {
+    // 読めなくても学習は続けられる。作り直しになるだけ。
+    logger.warn('日次計画を読み込めませんでした', error);
+    return null;
+  }
+};
+
+export const saveDailyPlan = async (userId, dateKey, payload) => {
+  if (!userId || !dateKey) return;
+  try {
+    await setDoc(doc(db, 'users', userId, 'dailyPlans', dateKey), {
+      dateKey,
+      planVersion: PLAN_VERSION,
+      generatedAt: new Date(),
+      answeredNewWordIds: [],
+      ...payload,
+    });
+  } catch (error) {
+    logger.warn('日次計画を保存できませんでした', error);
+  }
+};
+
+/**
+ * 回答した新規単語を記録する。
+ * 1語ずつ書くのは、途中でブラウザを閉じても取りこぼさないため。
+ */
+export const markNewWordAnswered = async (userId, dateKey, wordId) => {
+  if (!userId || !dateKey || !wordId) return;
+  try {
+    await updateDoc(doc(db, 'users', userId, 'dailyPlans', dateKey), {
+      answeredNewWordIds: arrayUnion(wordId),
+    });
+  } catch (error) {
+    logger.warn('日次計画の回答記録に失敗しました', error);
+  }
+};
+
+/** 回答済みを除いた残りを返す。順番は保存時のまま保つ。 */
+export const remainingWords = (words = [], answeredIds = []) => {
+  const answered = new Set(answeredIds);
+  return words.filter((word) => !answered.has(word?.id));
+};

--- a/src/logic/dailyPlanRepository.test.js
+++ b/src/logic/dailyPlanRepository.test.js
@@ -1,0 +1,81 @@
+import { PLAN_VERSION, isStoredPlanUsable, planSignature, remainingWords } from './dailyPlanRepository';
+
+const user = {
+  level: 4,
+  goal: {
+    targets: [{ goalId: 'eiken_2' }, { goalId: 'hs_60' }],
+    targetDate: '2026-09-01',
+    motivationLevel: 'normal',
+  },
+};
+
+describe('planSignature', () => {
+  test('同じ設定なら同じ署名', () => {
+    expect(planSignature(user)).toBe(planSignature({ ...user }));
+  });
+
+  test('目標の並び順が違っても同じ署名', () => {
+    const reordered = { ...user, goal: { ...user.goal, targets: [{ goalId: 'hs_60' }, { goalId: 'eiken_2' }] } };
+    expect(planSignature(reordered)).toBe(planSignature(user));
+  });
+
+  test.each([
+    ['達成日', { goal: { ...user.goal, targetDate: '2026-10-01' } }],
+    ['やる気', { goal: { ...user.goal, motivationLevel: 'high' } }],
+    ['目標', { goal: { ...user.goal, targets: [{ goalId: 'eiken_3' }] } }],
+    ['レベル', { level: 5 }],
+  ])('%s が変わると署名も変わる', (_label, patch) => {
+    expect(planSignature({ ...user, ...patch })).not.toBe(planSignature(user));
+  });
+
+  test('設定が空でも落ちない', () => {
+    expect(typeof planSignature(undefined)).toBe('string');
+    expect(typeof planSignature({})).toBe('string');
+  });
+});
+
+describe('isStoredPlanUsable', () => {
+  const signature = planSignature(user);
+  const stored = { planVersion: PLAN_VERSION, signature, newWords: [] };
+
+  test('版と署名が一致すれば使える', () => {
+    expect(isStoredPlanUsable(stored, signature)).toBe(true);
+  });
+
+  test('版が違えば作り直す', () => {
+    expect(isStoredPlanUsable({ ...stored, planVersion: PLAN_VERSION + 1 }, signature)).toBe(false);
+  });
+
+  test('設定が変わっていれば作り直す', () => {
+    expect(isStoredPlanUsable(stored, 'ちがう署名')).toBe(false);
+  });
+
+  test('newWords が壊れていれば作り直す', () => {
+    expect(isStoredPlanUsable({ ...stored, newWords: undefined }, signature)).toBe(false);
+  });
+
+  test('保存が無ければ作り直す', () => {
+    expect(isStoredPlanUsable(null, signature)).toBe(false);
+  });
+});
+
+describe('remainingWords', () => {
+  const words = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+  test('回答済みを除く', () => {
+    expect(remainingWords(words, ['b'])).toEqual([{ id: 'a' }, { id: 'c' }]);
+  });
+
+  test('並び順は保存時のまま', () => {
+    expect(remainingWords(words, []).map((w) => w.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('全部答えていれば空', () => {
+    expect(remainingWords(words, ['a', 'b', 'c'])).toEqual([]);
+  });
+
+  test('引数が無くても落ちない', () => {
+    expect(remainingWords()).toEqual([]);
+    expect(remainingWords(words)).toEqual(words);
+  });
+});

--- a/src/logic/learningPlanner.js
+++ b/src/logic/learningPlanner.js
@@ -110,13 +110,20 @@ export const generateDailyPlan = async (userData, userId) => {
   // 復習対象
   //--------------------------------------------------------------------------
   const reviewSnapshot = await getDocs(collection(db, 'users', userId, 'reviewWords'));
-  const enrichedReviewEntries = reviewSnapshot.docs
+  // 永続IDへ移行済みの旧文書は二重に出さない
+  const allProgressEntries = reviewSnapshot.docs
     .map((docSnapshot) => ({ id: docSnapshot.id, ...docSnapshot.data() }))
-    // 永続IDへ移行済みの旧文書は二重に出さない
-    .filter((entry) => !entry.migratedTo)
-    .map((entry) => enrichReviewWord(entry, today));
+    .filter((entry) => !entry.migratedTo);
 
-  const learnedWordIds = new Set(enrichedReviewEntries.map((entry) => entry.id));
+  // 一度でも学習した単語は新規に出さない。習得済みも含める。
+  // ここを復習候補から作ると、習得済みの単語が新規単語として
+  // 出題し直されてしまう。
+  const learnedWordIds = new Set(allProgressEntries.map((entry) => entry.id));
+
+  // 復習候補。習得済み（status: mastered）は履歴として残しているだけなので外す。
+  const enrichedReviewEntries = allProgressEntries
+    .filter((entry) => entry.status !== 'mastered')
+    .map((entry) => enrichReviewWord(entry, today));
 
   const dueForReview = sortReviewCandidates(
     enrichedReviewEntries.filter(

--- a/src/logic/learningPlanner.js
+++ b/src/logic/learningPlanner.js
@@ -5,6 +5,13 @@ import { buildThemeGroups, computeKnowledgeMap, getKnowledgeGaps } from './knowl
 import { getMotivationConfig, getTargetLevel, toGoalIds, getRecommendedTextbooks } from '../config';
 import { parseLocalDate, getTodayKey } from './dateKeys';
 import {
+  planSignature,
+  isStoredPlanUsable,
+  loadDailyPlan,
+  saveDailyPlan,
+  remainingWords,
+} from './dailyPlanRepository';
+import {
   computeNewWordsQuota,
   computeRemainingDays,
   dedupeAcross,
@@ -90,11 +97,11 @@ export const generateDailyPlan = async (userData, userId) => {
     return emptyPlan('invalid-target-date');
   }
 
-  const remainingWords = await estimateNeededWords(userData);
+  const remainingWordsCount = await estimateNeededWords(userData);
 
   // 期限由来の必要語数と、やる気レベルの希望語数の両方を出す（計画書10.2.3）
   const quota = computeNewWordsQuota({
-    remainingWords,
+    remainingWords: remainingWordsCount,
     remainingDays,
     preferredNewWords: motivation.newWordsQuota,
   });
@@ -118,6 +125,43 @@ export const generateDailyPlan = async (userData, userId) => {
         (entry.daysSinceLast != null && entry.daysSinceLast >= Math.max(3, entry.interval || 1))
     )
   );
+
+  //--------------------------------------------------------------------------
+  // 保存済みの計画があればそれを使う（その日のうちは並びを変えない）
+  //--------------------------------------------------------------------------
+  const dateKey = getTodayKey();
+  const signature = planSignature(userData);
+  const stored = await loadDailyPlan(userId, dateKey);
+
+  if (isStoredPlanUsable(stored, signature)) {
+    // 復習単語はIDだけ保存してある。今日の reviewWords から引き直す。
+    // 途中で習得完了になった単語は消えるので、その分だけ減る。
+    const byId = new Map(enrichedReviewEntries.map((entry) => [entry.id, entry]));
+    const storedReviewWords = (stored.reviewWordIds || [])
+      .map((id) => byId.get(id))
+      .filter(Boolean);
+
+    const answered = stored.answeredNewWordIds || [];
+    const restoredNewWords = remainingWords(stored.newWords, answered);
+
+    return {
+      ...emptyPlan(null),
+      newWords: restoredNewWords,
+      reviewWords: storedReviewWords,
+      reviewSessions: splitIntoSessions(storedReviewWords, REVIEW_SESSION_SIZE),
+      extraNewWords: remainingWords(stored.extraNewWords || [], answered),
+      dailyTarget: (stored.newWords || []).length,
+      preferredNewWords: stored.quota?.preferredNewWords ?? 0,
+      requiredNewWords: stored.quota?.requiredNewWords ?? 0,
+      plannedNewWords: stored.quota?.plannedNewWords ?? 0,
+      isFeasible: stored.quota?.isFeasible ?? true,
+      remainingDays,
+      remainingWords: remainingWordsCount,
+      knowledgeHints: stored.knowledgeHints || [],
+      dateKey,
+      fromStoredPlan: true,
+    };
+  }
 
   //--------------------------------------------------------------------------
   // 新規単語
@@ -169,6 +213,22 @@ export const generateDailyPlan = async (userData, userId) => {
   const themeGroups = buildThemeGroups([...newWords, ...extraNewWords, ...finalReviewWords]);
   const knowledgeHints = getKnowledgeGaps(themeGroups, knowledgeMap).slice(0, 3);
 
+  // その日のうちは同じ計画を返せるように保存する。
+  // 復習はIDだけ（reviewWords から引き直せる）、新規と隣接は中身ごと。
+  await saveDailyPlan(userId, dateKey, {
+    signature,
+    newWords,
+    extraNewWords,
+    reviewWordIds: finalReviewWords.map((word) => word.id),
+    knowledgeHints,
+    quota: {
+      preferredNewWords: quota.preferredNewWords,
+      requiredNewWords: quota.requiredNewWords,
+      plannedNewWords: quota.plannedNewWords,
+      isFeasible: quota.isFeasible,
+    },
+  });
+
   return {
     newWords,
     reviewWords: finalReviewWords,
@@ -181,8 +241,10 @@ export const generateDailyPlan = async (userData, userId) => {
     plannedNewWords: quota.plannedNewWords,
     isFeasible: quota.isFeasible,
     remainingDays,
-    remainingWords,
+    remainingWords: remainingWordsCount,
     knowledgeHints,
+    dateKey,
+    fromStoredPlan: false,
   };
 };
 

--- a/src/logic/reviewLogic.js
+++ b/src/logic/reviewLogic.js
@@ -1,5 +1,5 @@
 import { db } from '../firebaseConfig';
-import { doc, setDoc, getDoc, updateDoc, runTransaction } from 'firebase/firestore';
+import { doc, setDoc, getDoc, updateDoc, arrayUnion, arrayRemove } from 'firebase/firestore';
 import { logStudyEvent } from './studyLogger';
 import { MOTIVATION_LEVELS } from '../config';
 import { getTodayKey } from './dateKeys';
@@ -75,7 +75,7 @@ export const updateUserWordProgress = async (userId, word, answer, isReviewCompl
     today.setHours(0, 0, 0, 0); // 時間を正規化
     // 復習完了の場合は、完全に復習リストから除去
     if (isReviewComplete) {
-      await removeWordFromReview(userId, word.id);
+      await markWordAsMastered(userId, word.id);
       return { created: false, mastered: true };
     }
 
@@ -135,16 +135,10 @@ const addWordToDailyCache = async (userId, wordToCache) => {
     const dailyPlanSnap = await getDoc(dailyPlanRef);
 
     if (dailyPlanSnap.exists()) {
-      const currentPlan = dailyPlanSnap.data();
-      const reviewWords = currentPlan.reviewWords || [];
-      
-      const isAlreadyInList = reviewWords.some(w => w.id === wordToCache.id);
-
-      if (!isAlreadyInList) {
-        const updatedReviewWords = [...reviewWords, wordToCache];
-        await updateDoc(dailyPlanRef, { reviewWords: updatedReviewWords });
-        logger.debug(`キャッシュを更新しました: ${wordToCache.word}`);
-      }
+      // 日次計画は復習単語をIDの配列で持つ（dailyPlanRepository.js）。
+      // 以前は単語の中身の配列 reviewWords を持っていたので形が違う。
+      await updateDoc(dailyPlanRef, { reviewWordIds: arrayUnion(wordToCache.id) });
+      logger.debug(`今日の計画に戻しました: ${wordToCache.word}`);
     }
     // キャッシュが存在しない場合は何もしない。
     // 次回generateDailyPlanが呼ばれたときに、この単語を含んだ正しいプランが生成・キャッシュされるため。
@@ -158,7 +152,17 @@ const addWordToDailyCache = async (userId, wordToCache) => {
  * @param {string} userId ユーザーID
  * @param {string} wordId 削除する単語のID
  */
-export const removeWordFromReview = async (userId, wordId) => {
+/**
+ * 復習完了。文書は消さず status: mastered にする。
+ *
+ * 以前は削除していたため、習得済みだったという事実まで消えていた。
+ * 消えると「学習履歴の無い単語」に戻るので、新規単語として再び出題され、
+ * 習得語数の集計からも落ちる（計画書§2.1 / §6.1）。
+ *
+ * コレクション名は reviewWords のまま。改名は移行が必要なわりに
+ * 得られるのは名前だけで、履歴を残すという目的には要らない。
+ */
+export const markWordAsMastered = async (userId, wordId) => {
   if (!userId || !wordId) return;
 
   const reviewWordRef = doc(db, 'users', userId, 'reviewWords', wordId);
@@ -166,31 +170,26 @@ export const removeWordFromReview = async (userId, wordId) => {
   const dailyPlanRef = doc(db, 'users', userId, 'dailyPlans', todayStr);
 
   try {
-    // トランザクションを使用して、複数のドキュメント操作の原子性を保証
-    await runTransaction(db, async (transaction) => {
-      // 1. 最初にすべての読み取り操作を実行
-      const dailyPlanSnap = await transaction.get(dailyPlanRef);
-      
-      // 2. 次に書き込み操作を実行
-      // 復習リストから削除
-      transaction.delete(reviewWordRef);
+    await setDoc(reviewWordRef, {
+      status: 'mastered',
+      masteredAt: new Date(),
+      nextReviewDate: null,
+    }, { merge: true });
 
-      // 今日のキャッシュからも削除
-      if (dailyPlanSnap.exists()) {
-        const currentPlan = dailyPlanSnap.data();
-        const updatedReviewWords = currentPlan.reviewWords.filter(w => w.id !== wordId);
-        transaction.update(dailyPlanRef, { reviewWords: updatedReviewWords });
-      }
-    });
-    logger.debug(`単語(ID: ${wordId})が正常に削除されました。`);
-    
-    // 学習ログを記録
+    // 今日の計画からは外す
+    const dailyPlanSnap = await getDoc(dailyPlanRef);
+    if (dailyPlanSnap.exists()) {
+      await updateDoc(dailyPlanRef, { reviewWordIds: arrayRemove(wordId) });
+    }
+
+    logger.debug(`単語(ID: ${wordId})を習得済みにしました。`);
+
     await logStudyEvent(userId, {
       wordId: wordId,
       sessionType: 'review',
-      action: 'removed',
+      action: 'mastered',
     });
   } catch (error) {
-    console.error("単語の完全削除(トランザクション)に失敗しました:", error);
+    console.error('習得済みへの更新に失敗しました:', error);
   }
 };

--- a/src/logic/reviewScheduling.js
+++ b/src/logic/reviewScheduling.js
@@ -22,6 +22,21 @@ const HARD_INTERVAL_RATIO = 0.5;
 const MIN_EASE_FACTOR = 1.3;
 
 /**
+ * E-Factor の上限。
+ * 以前は上限が無く、しかも毎回答 easeFactorMultiplier を掛けていたため、
+ * 「そこそこ」(1.2) では12回正解で 27 まで発散し、間隔が 21,378,739日
+ * （約58,000年）になっていた。逆に「やる気満々」(0.8) では4回で下限に
+ * 張り付き、成績に関係なく3日間隔で回り続けていた。
+ */
+const MAX_EASE_FACTOR = 3.0;
+
+/**
+ * 間隔の上限（日）。
+ * 上限が無いと、一度離れた単語が事実上二度と出てこなくなる。
+ */
+const MAX_INTERVAL_DAYS = 365;
+
+/**
  * 3段階の回答か、旧来の真偽値かを受け取って q に直す。
  * 既存の呼び出し（isCorrect の真偽値）を壊さないため。
  */
@@ -42,19 +57,21 @@ export const toQuality = (answer) => {
  *
  * @param {{interval:number, repetitions:number, easeFactor:number}} state 現在の状態
  * @param {number} quality SM-2 の q(0-5)
- * @param {{intervalMultiplier:number, easeFactorMultiplier:number}} config やる気レベルの設定
+ * @param {{intervalMultiplier:number}} config やる気レベルの設定
  *
  * intervalMultiplier は逆向きの係数であることに注意。
  * そこそこ=1.5 / 普通=1 / やる気満々=0.7 で、やる気が高いほど間隔が
  * 短くなる（＝復習が多く回ってくる）。
  */
 export const nextSchedule = (state, quality, config) => {
-  const easeFactorMultiplier = config?.easeFactorMultiplier ?? 1;
   const intervalMultiplier = config?.intervalMultiplier ?? 1;
 
   const currentInterval = Number.isFinite(state?.interval) ? state.interval : 0;
   const currentRepetitions = Number.isFinite(state?.repetitions) ? state.repetitions : 0;
-  const currentEase = Number.isFinite(state?.easeFactor) ? state.easeFactor : 2.5;
+  // 保存済みのEase Factorが壊れている場合に備えて読み取り時に丸める。
+  // 上の不具合で 27 まで膨らんだ値や、下限に張り付いた値が既に入っている。
+  const storedEase = Number.isFinite(state?.easeFactor) ? state.easeFactor : 2.5;
+  const currentEase = Math.min(MAX_EASE_FACTOR, Math.max(MIN_EASE_FACTOR, storedEase));
 
   let interval;
   let repetitions;
@@ -65,12 +82,15 @@ export const nextSchedule = (state, quality, config) => {
     } else if (currentRepetitions === 1) {
       interval = Math.ceil(6 * intervalMultiplier);
     } else {
-      interval = Math.ceil(currentInterval * currentEase * easeFactorMultiplier * intervalMultiplier);
+      // やる気の反映は intervalMultiplier だけに任せる。
+      // easeFactorMultiplier も掛けると、やる気の効きが二重になっていた。
+      interval = Math.ceil(currentInterval * currentEase * intervalMultiplier);
     }
     // 「迷った」は覚えきれていないので、伸ばし方を抑える
     if (quality === ANSWER_QUALITY.hard) {
       interval = Math.max(1, Math.ceil(interval * HARD_INTERVAL_RATIO));
     }
+    if (interval > MAX_INTERVAL_DAYS) interval = MAX_INTERVAL_DAYS;
     repetitions = currentRepetitions + 1;
   } else {
     // 覚えていないものは間隔を空けない。今日のうちにもう一度出す。
@@ -78,9 +98,11 @@ export const nextSchedule = (state, quality, config) => {
     repetitions = 0;
   }
 
+  // Ease Factor は回答の質だけで動かす。やる気設定で掛けない。
   const delta = 0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02);
-  let easeFactor = (currentEase + delta) * easeFactorMultiplier;
+  let easeFactor = currentEase + delta;
   if (easeFactor < MIN_EASE_FACTOR) easeFactor = MIN_EASE_FACTOR;
+  if (easeFactor > MAX_EASE_FACTOR) easeFactor = MAX_EASE_FACTOR;
 
   return { interval, repetitions, easeFactor };
 };

--- a/src/logic/reviewScheduling.test.js
+++ b/src/logic/reviewScheduling.test.js
@@ -144,3 +144,53 @@ describe('初見の単語（進捗が無い状態からの1回答目）', () => 
       .toBeLessThan(nextSchedule(fresh, ANSWER_QUALITY.good, normal).easeFactor);
   });
 });
+
+describe('Ease Factor の暴走を防ぐ', () => {
+  // 以前は easeFactorMultiplier を毎回答 EF に掛けていたため、
+  // 「そこそこ」(1.2) で12回正解すると EF が 27 まで発散し、
+  // 間隔が約58,000年になっていた。
+  const runCorrect = (config, times) => {
+    let state = { interval: 0, repetitions: 0, easeFactor: 2.5 };
+    for (let i = 0; i < times; i += 1) {
+      state = { ...state, ...nextSchedule(state, ANSWER_QUALITY.good, config) };
+    }
+    return state;
+  };
+
+  test('やる気レベルによらず Ease Factor は 1.3〜3.0 に収まる', () => {
+    for (const key of ['low', 'normal', 'high']) {
+      const state = runCorrect(MOTIVATION_LEVELS[key], 30);
+      expect(state.easeFactor).toBeGreaterThanOrEqual(1.3);
+      expect(state.easeFactor).toBeLessThanOrEqual(3.0);
+    }
+  });
+
+  test('やる気満々でも Ease Factor が下限に張り付かない', () => {
+    // 以前は4回正解で 1.3 に落ち、成績と無関係に3日間隔で回り続けていた
+    const state = runCorrect(MOTIVATION_LEVELS.high, 10);
+    expect(state.easeFactor).toBeGreaterThan(1.3);
+  });
+
+  test('間隔は365日を超えない', () => {
+    for (const key of ['low', 'normal', 'high']) {
+      const state = runCorrect(MOTIVATION_LEVELS[key], 30);
+      expect(state.interval).toBeLessThanOrEqual(365);
+    }
+  });
+
+  test('保存済みの壊れた Ease Factor を読み取り時に丸める', () => {
+    // 既存ユーザーには 27 まで膨らんだ値が入っている
+    const broken = nextSchedule({ interval: 10, repetitions: 3, easeFactor: 27 }, ANSWER_QUALITY.good, normal);
+    expect(broken.easeFactor).toBeLessThanOrEqual(3.0);
+    expect(broken.interval).toBeLessThanOrEqual(365);
+  });
+
+  test('やる気の効きが二重にならない', () => {
+    // interval と easeFactor の両方に倍率を掛けていたため、
+    // やる気満々では 0.7 × 0.8 = 0.56 倍が毎回かかっていた
+    const state = { interval: 10, repetitions: 3, easeFactor: 2.5 };
+    const high = nextSchedule(state, ANSWER_QUALITY.good, MOTIVATION_LEVELS.high).interval;
+    const expected = Math.ceil(10 * 2.5 * MOTIVATION_LEVELS.high.intervalMultiplier);
+    expect(high).toBe(expected);
+  });
+});

--- a/src/logic/reviewScheduling.test.js
+++ b/src/logic/reviewScheduling.test.js
@@ -194,3 +194,32 @@ describe('Ease Factor の暴走を防ぐ', () => {
     expect(high).toBe(expected);
   });
 });
+
+describe('習得済みの扱い', () => {
+  // 復習完了は文書削除ではなく status: mastered への変更にした。
+  // 計画側は「一度でも学習した単語」を新規から除くために全履歴を見て、
+  // 「復習候補」からだけ mastered を外す。この2つを取り違えると、
+  // 習得済みの単語が新規単語として出題し直される。
+  const entries = [
+    { id: 'a', status: undefined },
+    { id: 'b', status: 'mastered' },
+    { id: 'c', migratedTo: 'x' },
+  ];
+
+  const notMigrated = entries.filter((e) => !e.migratedTo);
+  const learnedIds = new Set(notMigrated.map((e) => e.id));
+  const reviewCandidates = notMigrated.filter((e) => e.status !== 'mastered');
+
+  test('習得済みも「学習済み」に数える（新規に戻さない）', () => {
+    expect(learnedIds.has('b')).toBe(true);
+  });
+
+  test('習得済みは復習候補には出さない', () => {
+    expect(reviewCandidates.map((e) => e.id)).toEqual(['a']);
+  });
+
+  test('移行済みの旧文書はどちらにも出さない', () => {
+    expect(learnedIds.has('c')).toBe(false);
+    expect(reviewCandidates.some((e) => e.id === 'c')).toBe(false);
+  });
+});


### PR DESCRIPTION
`LEARNING_LOGIC_FIX_PLAN.md` の残り3件を順に対応。

## 1. Ease Factor の発散とやる気の二重適用（§6.2）

`easeFactorMultiplier` を毎回答 EF に掛けていたため、成績ではなく設定で EF が指数的に流されていた。全問正解を続けた場合:

| 設定 | 12回後のEF | 8回後の間隔 |
|---|---|---|
| そこそこ(1.2) | **27.04** | **21,378,739日（約58,000年）** |
| やる気満々(0.8) | 1.30（4回で下限に張り付き） | 3日で固定 |

さらに間隔計算で `easeFactorMultiplier` と `intervalMultiplier` の両方を掛けており、やる気が二重に効いていた。

- EF は回答の質だけで動かす。上限3.0
- 間隔は `intervalMultiplier` だけでやる気を反映
- 間隔の上限365日
- 保存済みの壊れたEFは読み取り時に丸める（移行不要）

修正後: そこそこ `1 9 37 156 365` / 普通 `1 6 17 48 140` / やる気満々 `1 5 10 20 41 87 183`

## 2. 日次計画の固定（§2.4 / §8.2）

開くたびに `Math.random` で抽選し直していた。`dailyPlans/{YYYY-MM-DD}` に保存し、目標・達成日・やる気・レベルの署名が変わったときだけ作り直す。回答した新規単語を1語ずつ記録し、途中で閉じても残りから再開する。

本番実測: 入り直しても先頭は同じ語。2語answered後に 20 → 18 になり、ハードリロード後も18のまま。

## 3. 習得履歴の保持（§2.1 / §6.1）

復習完了が文書削除だったため、習得済みの事実まで消え、新規単語として再出題されていた。`status: 'mastered'` に変更。コレクション改名はしない（移行が必要なわりに得られるのは名前だけ）。

**作業中に見つけた自己起因のバグ**: 2 で日次計画の形を変えたため、`removeWordFromReview` が読む `reviewWords` 配列が存在しなくなり、`undefined.filter` でトランザクションごと失敗して復習完了が動かなくなっていた。`reviewWordIds` へ揃えて修正。

## 検証

テスト219件パス（+24）、lint クリーン。1と2は本番で実測。3は単体テストとコードレビューまで（上スワイプの自動操作が再現できず、実機での復習完了は未実施）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)