### PR TITLE
feat(rank): ランク体系（E〜SS）と参考換算の表示基盤

### DIFF
--- a/src/StudentDashboard.js
+++ b/src/StudentDashboard.js
@@ -16,10 +16,11 @@ import StoryPanel from './components/student/StoryPanel';
 import { useBookmarks } from './logic/useBookmarks';
 import { markNewWordAnswered } from './logic/dailyPlanRepository';
 import ReviewFlashcard from './ReviewFlashcard';
-import LevelBadge from './LevelBadge';
+import RankCard from './components/assessment/RankCard';
 import { FaBook, FaSyncAlt, FaMagic, FaStar } from 'react-icons/fa';
 import { getTodayKey, getCurrentMonthKey, getTokyoDateKey, parseLocalDate } from './logic/dateKeys';
 import { getRecommendedTextbooks, toGoalIds, getMotivationConfig, LEVELS } from './config';
+import { bestRankOf, rankForScore, scoreFromLegacyLevel } from './logic/rankLogic';
 import { normalizeStory, isDisplayableStory } from './logic/storyView';
 import { StudentHeader, StudentBottomNav } from './components/layout/StudentShell';
 import { loadWordMaster, loadManifest } from './logic/wordMaster';
@@ -459,6 +460,11 @@ export default function StudentDashboard() {
   const [testWords, setTestWords] = useState([]);
   const [currentSessionInfo, setCurrentSessionInfo] = useState(null);
   const [userData, setUserData] = useState(null);
+  // 能力スコアとランク。現行の level からの暫定換算（計画書12 フェーズ1）。
+  const abilityScore = scoreFromLegacyLevel(testResultLevel);
+  const currentRankId = rankForScore(abilityScore)?.id ?? null;
+  // 自己ベストは下がっても消さない。保存済みが無ければ現在値を使う。
+  const bestRankId = bestRankOf(userData?.assessment?.bestRank ?? null, currentRankId);
   const [dailyPlan, setDailyPlan] = useState({ newWords: [], reviewWords: [], extraNewWords: [] });
   const [showRetestPrompt, setShowRetestPrompt] = useState(false);
   const [isDailyTaskCompleted, setIsDailyTaskCompleted] = useState(false);
@@ -1642,49 +1648,15 @@ export default function StudentDashboard() {
             </div>
 
             <div className="section-card">
-              <div className="dashboard-header" style={{ position: 'relative' }}>
-                <LevelBadge level={testResultLevel} />
-                {testResultLevel > 0 && (
-                <button
-                  onClick={startCheckTest}
-                  style={{ 
-                    position: 'absolute',
-                    bottom: '-8px',
-                    right: '-8px',
-                    fontSize: '0.7rem',
-                    padding: '4px 8px',
-                    border: '1px solid #e5e7eb',
-                    borderRadius: '12px',
-                    background: '#f8fafc',
-                    color: '#6b7280',
-                    cursor: 'pointer',
-                    transition: 'all 0.2s',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '3px',
-                    fontWeight: '500',
-                    height: '24px',
-                    minWidth: '60px',
-                    justifyContent: 'center',
-                    zIndex: 10,
-                    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)'
-                  }}
-                  onMouseOver={(e) => {
-                    e.target.style.background = '#e5e7eb';
-                    e.target.style.color = '#374151';
-                    e.target.style.transform = 'scale(1.05)';
-                  }}
-                  onMouseOut={(e) => {
-                    e.target.style.background = '#f8fafc';
-                    e.target.style.color = '#6b7280';
-                    e.target.style.transform = 'scale(1)';
-                  }}
-                >
-                  <FaSyncAlt style={{ fontSize: '0.65rem' }} />
-                  再テスト
-                </button>
-                )}
-              </div>
+              {/* レベルの直接表示をランク表示へ置き換える（計画書12 フェーズ1-2）。
+                  現行テストは自己申告型で正式ランク判定には使えないため、
+                  既存 level から代表スコアへ写した暫定表示。信頼度は low。 */}
+              <RankCard
+                score={abilityScore}
+                bestRankId={bestRankId}
+                onRetest={testResultLevel > 0 ? startCheckTest : undefined}
+                compact
+              />
 
               {/* 学習計画最適化ボタン */}
               {showRetestPrompt && (

--- a/src/components/assessment/RankBadge.css
+++ b/src/components/assessment/RankBadge.css
@@ -1,0 +1,127 @@
+/*
+ * ランク紋章。ASSESSMENT_RANK_SYSTEM_PLAN.md 8.3。
+ *
+ * 基準色（ライム / キャンバス / オリーブ / アクセントブルー / 白）は増やさない。
+ * ランク差は枠・面・光沢・縁光の付け方だけで表す。
+ */
+
+.rank-badge {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-card);
+  background-color: var(--color-surface);
+  color: var(--color-ink-olive);
+  font-family: var(--font-family-heading);
+  line-height: 1;
+}
+
+.rank-badge__letter {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.rank-badge__caption {
+  margin-top: var(--space-4);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-12);
+  font-weight: 400;
+  color: var(--color-olive-muted);
+}
+
+/* ---- 大きさ ---- */
+.rank-badge--small {
+  width: 44px;
+  height: 44px;
+}
+.rank-badge--small .rank-badge__letter {
+  font-size: var(--font-size-18);
+}
+
+.rank-badge--medium {
+  width: 72px;
+  height: 72px;
+}
+.rank-badge--medium .rank-badge__letter {
+  font-size: var(--font-size-28);
+}
+
+.rank-badge--large {
+  width: 108px;
+  height: 108px;
+}
+.rank-badge--large .rank-badge__letter {
+  font-size: var(--font-size-40);
+}
+
+/* ---- ランクごとの表現（計画書8.3の表） ---- */
+
+/* E: 細い1本枠、影なし */
+.rank-badge--plain {
+  border: 1px solid var(--color-olive-border);
+}
+
+/* D: 1本枠、薄い面 */
+.rank-badge--soft {
+  border: 1px solid var(--color-olive-border);
+  background-color: var(--color-lime-soft);
+}
+
+/* C: 二重枠 */
+.rank-badge--double {
+  border: 2px solid var(--color-lime-border);
+  box-shadow: inset 0 0 0 4px var(--color-surface), inset 0 0 0 5px var(--color-lime-border);
+  background-color: var(--color-lime-soft);
+}
+
+/* B: 二重枠と小さな光沢 */
+.rank-badge--double-gloss {
+  border: 2px solid var(--color-lime-border);
+  box-shadow:
+    inset 0 0 0 4px var(--color-surface),
+    inset 0 0 0 5px var(--color-lime-border),
+    inset 0 12px 16px -12px rgba(255, 255, 255, 0.9);
+  background-image: linear-gradient(160deg, var(--color-lime-muted), var(--color-lime-soft));
+}
+
+/* A: 太い枠と立体的な紋章 */
+.rank-badge--bold {
+  border: 3px solid var(--color-brand-lime);
+  box-shadow:
+    inset 0 0 0 5px var(--color-surface),
+    var(--shadow-2);
+  background-image: linear-gradient(160deg, var(--color-lime-muted), var(--color-lime-soft));
+}
+
+/* S: ブルーの縁光と静かなシマー */
+.rank-badge--aura {
+  border: 3px solid var(--color-brand-lime);
+  box-shadow:
+    inset 0 0 0 5px var(--color-surface),
+    0 0 0 3px rgba(59, 130, 246, 0.28),
+    var(--shadow-2);
+  background-image: linear-gradient(160deg, var(--color-lime-muted), var(--color-lime-soft));
+}
+
+/* SS: ライムとブルーの二重光、専用紋章 */
+.rank-badge--crest {
+  border: 3px solid var(--color-brand-lime);
+  box-shadow:
+    inset 0 0 0 5px var(--color-surface),
+    0 0 0 3px rgba(163, 230, 53, 0.55),
+    0 0 0 6px rgba(59, 130, 246, 0.35),
+    var(--shadow-3);
+  background-image: linear-gradient(160deg, var(--color-lime-muted), rgba(59, 130, 246, 0.10));
+}
+
+/* 未解放。見せてもよいが、獲得済みには見せない（計画書2.3） */
+.rank-badge--locked {
+  opacity: 0.55;
+  filter: grayscale(0.35);
+}
+
+.rank-badge--unmeasured {
+  border: 1px dashed var(--color-olive-border);
+  color: var(--color-olive-muted);
+}

--- a/src/components/assessment/RankBadge.js
+++ b/src/components/assessment/RankBadge.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { getRank } from '../../logic/rankLogic';
+import './RankBadge.css';
+
+/**
+ * ランクの紋章。ASSESSMENT_RANK_SYSTEM_PLAN.md 8.3。
+ *
+ * 色は増やさない。ランク差は枠の太さ・二重線・光沢・縁光で表す。
+ * 常時点滅はしない。SSでも本文の可読性を優先する。
+ */
+export default function RankBadge({ rankId, size = 'medium', locked = false }) {
+  const rank = getRank(rankId);
+
+  if (!rank) {
+    return (
+      <div className={`rank-badge rank-badge--${size} rank-badge--unmeasured`}>
+        <span className="rank-badge__letter">—</span>
+        <span className="rank-badge__caption">未測定</span>
+      </div>
+    );
+  }
+
+  const className = [
+    'rank-badge',
+    `rank-badge--${size}`,
+    `rank-badge--${rank.style}`,
+    locked || rank.locked ? 'rank-badge--locked' : '',
+  ].filter(Boolean).join(' ');
+
+  return (
+    <div className={className} aria-label={`ランク ${rank.id}`}>
+      <span className="rank-badge__letter">{rank.id}</span>
+      {(locked || rank.locked) && <span className="rank-badge__caption">測定準備中</span>}
+    </div>
+  );
+}

--- a/src/components/assessment/RankCard.css
+++ b/src/components/assessment/RankCard.css
@@ -1,0 +1,204 @@
+/* ランクカード。ASSESSMENT_RANK_SYSTEM_PLAN.md 8.1 */
+
+.rank-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.rank-card__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-16);
+}
+
+.rank-card__summary {
+  flex: 1;
+  min-width: 0;
+}
+
+.rank-card__label {
+  margin: 0;
+  font-size: var(--font-size-12);
+  color: var(--color-olive-muted);
+}
+
+.rank-card__score {
+  margin: 0;
+  font-family: var(--font-family-heading);
+  font-size: var(--font-size-28);
+  font-weight: 700;
+  color: var(--color-ink-olive);
+  line-height: 1.1;
+}
+
+.rank-card__range {
+  margin-left: var(--space-8);
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-12);
+  font-weight: 400;
+  color: var(--color-olive-muted);
+}
+
+.rank-card__meta {
+  margin: var(--space-4) 0 0;
+  font-size: var(--font-size-12);
+  color: var(--color-olive-muted);
+}
+
+.rank-card__diff {
+  color: var(--color-ink-olive);
+}
+
+/* ---- 次ランクまで ---- */
+.rank-card__progress-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--space-4);
+  font-size: var(--font-size-12);
+  color: var(--color-olive-muted);
+}
+
+.rank-card__percent {
+  font-variant-numeric: tabular-nums;
+}
+
+.rank-card__bar {
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background-color: var(--color-lime-soft);
+  overflow: hidden;
+}
+
+.rank-card__bar-fill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background-color: var(--color-brand-lime);
+  transition: width var(--motion-card) var(--ease-standard);
+}
+
+/* ---- 英検・TOEIC 換算（補助情報として小さく） ---- */
+.rank-card__equivalency {
+  padding-top: var(--space-8);
+  border-top: var(--border-subtle);
+}
+
+.rank-card__eq-line {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-12);
+  color: var(--color-olive-muted);
+}
+
+.rank-card__detail-toggle {
+  margin-top: var(--space-4);
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-12);
+  color: var(--color-accent-blue);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.rank-card__detail {
+  margin-top: var(--space-8);
+  padding: var(--space-12);
+  border-radius: var(--radius-control);
+  background-color: var(--color-canvas-lime);
+  font-size: var(--font-size-12);
+  color: var(--color-olive-muted);
+  line-height: var(--line-normal);
+}
+
+.rank-card__detail p {
+  margin: 0 0 var(--space-8);
+}
+
+.rank-card__detail dl {
+  display: grid;
+  gap: var(--space-4);
+  margin: 0;
+}
+
+.rank-card__detail dl > div {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-12);
+}
+
+.rank-card__detail dt {
+  margin: 0;
+}
+
+.rank-card__detail dd {
+  margin: 0;
+  color: var(--color-ink-olive);
+  text-align: right;
+}
+
+.rank-card__retest {
+  align-self: flex-start;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rank-card__bar-fill {
+    transition: none;
+  }
+}
+
+/* ---- ホーム用。1画面に収めるため行と余白を詰める ---- */
+.rank-card--compact {
+  gap: var(--space-4);
+}
+
+.rank-card--compact .rank-card__head {
+  gap: var(--space-12);
+}
+
+.rank-card--compact .rank-card__score {
+  font-size: var(--font-size-22);
+}
+
+.rank-card--compact .rank-card__equivalency {
+  padding-top: var(--space-4);
+}
+
+/* 換算の1行と「換算について」を同じ行に並べる */
+.rank-card--compact .rank-card__equivalency {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-8);
+}
+
+.rank-card--compact .rank-card__eq-line {
+  margin: 0;
+}
+
+.rank-card--compact .rank-card__detail-toggle {
+  margin-top: 0;
+}
+
+.rank-card--compact .rank-card__detail {
+  flex-basis: 100%;
+}
+
+/* 紋章は少し小さく */
+.rank-card--compact .rank-badge--medium {
+  width: 60px;
+  height: 60px;
+}
+
+.rank-card__retest-link {
+  margin-left: var(--space-8);
+  padding: 0;
+  border: none;
+  background: none;
+  font-family: var(--font-family-body);
+  font-size: var(--font-size-12);
+  color: var(--color-accent-blue);
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/src/components/assessment/RankCard.js
+++ b/src/components/assessment/RankCard.js
@@ -1,0 +1,163 @@
+import React, { useState } from 'react';
+import RankBadge from './RankBadge';
+import {
+  DISCLAIMER,
+  getRank,
+  nextRank,
+  pointsToNextRank,
+  progressWithinRank,
+  rankForScore,
+} from '../../logic/rankLogic';
+import { buildEquivalency } from '../../logic/examEquivalency';
+import './RankCard.css';
+
+/**
+ * ホームと結果画面で使うランクカード。
+ * ASSESSMENT_RANK_SYSTEM_PLAN.md 8.1 / 10.3。
+ *
+ * 大きなランク文字を主役にし、英検・TOEIC換算は補助情報として小さく置く。
+ * 換算は必ず注記付きで、断定表現にしない。
+ */
+export default function RankCard({
+  score,
+  bestRankId,
+  previousScore,
+  confidenceLow,
+  confidenceHigh,
+  onRetest,
+  compact = false,
+}) {
+  const [showDetail, setShowDetail] = useState(false);
+
+  const rank = rankForScore(score);
+  const equivalency = buildEquivalency({ score });
+
+  if (!rank) {
+    return (
+      <div className="rank-card">
+        <div className="rank-card__head">
+          <RankBadge rankId={null} size={compact ? 'medium' : 'large'} />
+          <div className="rank-card__summary">
+            <p className="rank-card__label">まだ実力を測っていません</p>
+            {onRetest && (
+              <button type="button" className="primary-action" onClick={onRetest}>
+                実力テストを受ける
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const next = nextRank(rank.id);
+  const remaining = pointsToNextRank(score);
+  const percent = Math.round(progressWithinRank(score) * 100);
+  const best = getRank(bestRankId);
+  const diff = Number.isFinite(previousScore) ? Math.round(score - previousScore) : null;
+  const hasRange = Number.isFinite(confidenceLow) && Number.isFinite(confidenceHigh);
+
+  return (
+    <div className={compact ? 'rank-card rank-card--compact' : 'rank-card'}>
+      <div className="rank-card__head">
+        <RankBadge rankId={rank.id} size={compact ? 'medium' : 'large'} />
+        <div className="rank-card__summary">
+          <p className="rank-card__label">能力スコア</p>
+          <p className="rank-card__score">
+            {Math.round(score)}
+            {hasRange && (
+              <span className="rank-card__range">
+                （推定範囲 {Math.round(confidenceLow)}〜{Math.round(confidenceHigh)}）
+              </span>
+            )}
+          </p>
+          <p className="rank-card__meta">
+            {best && <>自己ベスト {best.id}</>}
+            {diff !== null && (
+              <span className="rank-card__diff">{diff >= 0 ? ` / 前回 +${diff}` : ` / 前回 ${diff}`}</span>
+            )}
+            {/* ホームでは行を増やさないよう、受け直しは小さなリンクにする */}
+            {compact && onRetest && (
+              <button type="button" className="rank-card__retest-link" onClick={onRetest}>
+                受け直す
+              </button>
+            )}
+          </p>
+        </div>
+      </div>
+
+      {next && (
+        <div className="rank-card__progress">
+          <div className="rank-card__progress-head">
+            <span>
+              {next.locked ? `${next.id} は測定準備中` : `次の ${next.id} ランクまで あと ${remaining}`}
+            </span>
+            <span className="rank-card__percent">{percent}%</span>
+          </div>
+          <div
+            className="rank-card__bar"
+            role="progressbar"
+            aria-valuenow={percent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${rank.id} ランク内の進み具合`}
+          >
+            <div className="rank-card__bar-fill" style={{ width: `${percent}%` }} />
+          </div>
+        </div>
+      )}
+
+      {equivalency && !equivalency.locked && (
+        <div className="rank-card__equivalency">
+          {compact ? (
+            <p className="rank-card__eq-line">
+              {equivalency.eiken}・{equivalency.toeic.min}〜{equivalency.toeic.max}点
+            </p>
+          ) : (
+            <>
+              <p className="rank-card__eq-line">{equivalency.eiken}</p>
+              <p className="rank-card__eq-line">{equivalency.toeic.label}</p>
+            </>
+          )}
+          <button
+            type="button"
+            className="rank-card__detail-toggle"
+            onClick={() => setShowDetail((prev) => !prev)}
+            aria-expanded={showDetail}
+          >
+            {showDetail ? '詳しい説明を閉じる' : '換算について'}
+          </button>
+          {showDetail && (
+            <div className="rank-card__detail">
+              <p>{DISCLAIMER}</p>
+              <dl>
+                <div>
+                  <dt>CEFR の目安</dt>
+                  <dd>{equivalency.cefr}</dd>
+                </div>
+                <div>
+                  <dt>測っていない技能</dt>
+                  <dd>{equivalency.notMeasured.join(' / ')}</dd>
+                </div>
+                <div>
+                  <dt>信頼度</dt>
+                  <dd>{equivalency.confidence.label}</dd>
+                </div>
+                <div>
+                  <dt>換算表</dt>
+                  <dd>v{equivalency.tableVersion}</dd>
+                </div>
+              </dl>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!compact && onRetest && (
+        <button type="button" className="secondary-action rank-card__retest" onClick={onRetest}>
+          実力テストを受け直す
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/config/ranks.json
+++ b/src/config/ranks.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "note": "ASSESSMENT_RANK_SYSTEM_PLAN.md 3.2 の初期換算テーブル。正式な境界は実測データで再調整する。",
+  "scoreMin": 0,
+  "scoreMax": 1000,
+  "ranks": [
+    {
+      "id": "E",
+      "min": 0,
+      "max": 149,
+      "cefr": "Pre-A1",
+      "eiken": "英検5級相当の目安",
+      "toeic": { "min": 10, "max": 115 },
+      "style": "plain",
+      "locked": false
+    },
+    {
+      "id": "D",
+      "min": 150,
+      "max": 274,
+      "cefr": "A1",
+      "eiken": "英検4級相当の目安",
+      "toeic": { "min": 120, "max": 220 },
+      "style": "soft",
+      "locked": false
+    },
+    {
+      "id": "C",
+      "min": 275,
+      "max": 424,
+      "cefr": "A2前半",
+      "eiken": "英検3級相当の目安",
+      "toeic": { "min": 225, "max": 380 },
+      "style": "double",
+      "locked": false
+    },
+    {
+      "id": "B",
+      "min": 425,
+      "max": 574,
+      "cefr": "A2後半",
+      "eiken": "英検準2級〜準2級プラス相当の目安",
+      "toeic": { "min": 385, "max": 545 },
+      "style": "double-gloss",
+      "locked": false
+    },
+    {
+      "id": "A",
+      "min": 575,
+      "max": 724,
+      "cefr": "B1",
+      "eiken": "英検2級相当の目安",
+      "toeic": { "min": 550, "max": 780 },
+      "style": "bold",
+      "locked": false
+    },
+    {
+      "id": "S",
+      "min": 725,
+      "max": 849,
+      "cefr": "B2",
+      "eiken": "英検準1級相当の目安",
+      "toeic": { "min": 785, "max": 940 },
+      "style": "aura",
+      "locked": false
+    },
+    {
+      "id": "SS",
+      "min": 850,
+      "max": 1000,
+      "cefr": "C1",
+      "eiken": "英検1級相当の目安",
+      "toeic": { "min": 945, "max": 990 },
+      "style": "crest",
+      "locked": true,
+      "lockedReason": "C1相当の問題バンクが未整備のため、正式判定は行わない（計画書2.3）"
+    }
+  ],
+  "levelToScore": {
+    "note": "現行の実力テストは自己申告型で、計画書4.1により正式ランク判定には使えない。移行期間中は既存の level(1〜7) から代表値へ写して表示だけ行う。信頼度は low 固定。",
+    "1": 75,
+    "2": 210,
+    "3": 350,
+    "4": 470,
+    "5": 610,
+    "6": 690,
+    "7": 780
+  },
+  "disclaimer": "この結果は、つくたん独自テストによる語彙・読解・Listening基礎の推定です。英検の合否やTOEIC公式スコアを保証するものではありません。"
+}

--- a/src/logic/examEquivalency.js
+++ b/src/logic/examEquivalency.js
@@ -1,0 +1,80 @@
+import { DISCLAIMER, RANKS_VERSION, getRank, rankForScore } from './rankLogic';
+
+/**
+ * 英検・TOEIC の参考換算。
+ * ASSESSMENT_RANK_SYSTEM_PLAN.md 7章。
+ *
+ * 単語テストだけで公式スコアを断定しない（計画書2.2）。
+ * 表示は必ず「相当の目安」「参考レンジ」にし、断定表現を作らない。
+ */
+
+export { DISCLAIMER };
+
+/** 信頼度。段階1（CEFR経由の暫定換算）は low 〜 medium まで。 */
+export const CONFIDENCE = {
+  low: { id: 'low', label: '参考換算・低信頼度' },
+  medium: { id: 'medium', label: '参考換算・中信頼度' },
+};
+
+/** TOEIC は5点刻みで丸める（計画書13.4）。 */
+export const roundToeic = (value) => Math.round(value / 5) * 5;
+
+/**
+ * 換算結果を作る。
+ *
+ * @param {object} params
+ * @param {number} params.score 能力スコア
+ * @param {'low'|'medium'} [params.confidence] 換算の信頼度
+ * @returns {object|null} 未測定なら null
+ */
+export const buildEquivalency = ({ score, confidence = 'low' } = {}) => {
+  const rank = rankForScore(score);
+  if (!rank) return null;
+
+  // ロック中のランクの換算は出さない。
+  // 「英検1級相当」を根拠なく見せないため（計画書13.4）。
+  if (rank.locked) {
+    return {
+      rankId: rank.id,
+      locked: true,
+      cefr: null,
+      eiken: null,
+      toeic: null,
+      confidence: CONFIDENCE.low,
+      tableVersion: RANKS_VERSION,
+      disclaimer: DISCLAIMER,
+    };
+  }
+
+  return {
+    rankId: rank.id,
+    locked: false,
+    cefr: rank.cefr,
+    eiken: rank.eiken,
+    toeic: {
+      min: roundToeic(rank.toeic.min),
+      max: roundToeic(rank.toeic.max),
+      label: `TOEIC L&R ${roundToeic(rank.toeic.min)}〜${roundToeic(rank.toeic.max)}点の参考レンジ`,
+    },
+    confidence: CONFIDENCE[confidence] || CONFIDENCE.low,
+    tableVersion: RANKS_VERSION,
+    disclaimer: DISCLAIMER,
+    // 測っていない技能を明示する（計画書7.3）
+    notMeasured: ['Speaking', 'Writing'],
+  };
+};
+
+/**
+ * 信頼区間からランク表示の文言を作る。
+ * 境界付近で精度が低いときは断定せず範囲で伝える（計画書3.3）。
+ */
+export const rankRangeLabel = ({ score, confidenceLow, confidenceHigh }) => {
+  const rank = rankForScore(score);
+  if (!rank) return '未測定';
+
+  const low = getRank(rankForScore(confidenceLow)?.id)?.id;
+  const high = getRank(rankForScore(confidenceHigh)?.id)?.id;
+
+  if (low && high && low !== high) return `${low}〜${high}`;
+  return rank.id;
+};

--- a/src/logic/rankLogic.js
+++ b/src/logic/rankLogic.js
@@ -1,0 +1,164 @@
+import RANKS from '../config/ranks.json';
+
+/**
+ * ランク（E 〜 SS）の判定。
+ * ASSESSMENT_RANK_SYSTEM_PLAN.md 3章 / 8.4。
+ *
+ * ランクは「実力テストで確認できた能力」を表す。学習回数や連続日数では
+ * 上がらない（計画書2.1）。
+ */
+
+export const RANK_LIST = RANKS.ranks;
+export const RANK_IDS = RANK_LIST.map((rank) => rank.id);
+export const SCORE_MIN = RANKS.scoreMin;
+export const SCORE_MAX = RANKS.scoreMax;
+export const DISCLAIMER = RANKS.disclaimer;
+export const RANKS_VERSION = RANKS.version;
+
+/** 未受験。ランクには含めない（計画書3.1）。 */
+export const UNMEASURED = { id: null, label: '未測定' };
+
+const clampScore = (score) =>
+  Math.min(SCORE_MAX, Math.max(SCORE_MIN, score));
+
+/** 能力スコアからランク定義を返す。数値でなければ null（未測定）。 */
+export const rankForScore = (score) => {
+  if (!Number.isFinite(score)) return null;
+  const value = clampScore(score);
+  return RANK_LIST.find((rank) => value >= rank.min && value <= rank.max) || null;
+};
+
+export const getRank = (rankId) => RANK_LIST.find((rank) => rank.id === rankId) || null;
+
+/** 並び順の添字。比較に使う。未知は -1。 */
+export const rankIndex = (rankId) => RANK_IDS.indexOf(rankId);
+
+/** ひとつ上のランク。最上位なら null。 */
+export const nextRank = (rankId) => {
+  const index = rankIndex(rankId);
+  if (index < 0 || index >= RANK_LIST.length - 1) return null;
+  return RANK_LIST[index + 1];
+};
+
+/**
+ * 判定に使えるランクか。
+ * SS は C1 問題バンクが未整備なので正式判定しない（計画書2.3）。
+ */
+export const isAwardable = (rankId) => {
+  const rank = getRank(rankId);
+  return Boolean(rank) && !rank.locked;
+};
+
+/**
+ * 正式に付与できる範囲へ丸める。
+ * ロックされたランクに届いても、ひとつ下までしか出さない。
+ */
+export const clampToAwardable = (rankId) => {
+  let index = rankIndex(rankId);
+  if (index < 0) return null;
+  while (index >= 0 && RANK_LIST[index].locked) index -= 1;
+  return index >= 0 ? RANK_LIST[index].id : null;
+};
+
+/** 次のランクまであと何点か。最上位・未測定なら null。 */
+export const pointsToNextRank = (score) => {
+  const rank = rankForScore(score);
+  if (!rank) return null;
+  const next = nextRank(rank.id);
+  if (!next) return null;
+  return Math.max(0, next.min - clampScore(score));
+};
+
+/** 現ランク内の進み具合（0〜1）。 */
+export const progressWithinRank = (score) => {
+  const rank = rankForScore(score);
+  if (!rank) return 0;
+  const span = rank.max - rank.min;
+  if (span <= 0) return 1;
+  return Math.min(1, Math.max(0, (clampScore(score) - rank.min) / span));
+};
+
+/**
+ * 昇格・維持・降格を決める（計画書8.4）。
+ *
+ * 昇格は信頼区間の下限が次ランク境界を超えたときだけ。点推定だけで
+ * 上げると、1回の当たりで上がって次に下がる。
+ * 降格は上限が現ランク下限を下回る結果が2回続いたときだけ。
+ *
+ * @param {object} params
+ * @param {string|null} params.currentRankId 今のランク
+ * @param {number} params.score 能力スコア
+ * @param {number} params.confidenceLow 信頼区間の下限
+ * @param {number} params.confidenceHigh 信頼区間の上限
+ * @param {number} params.consecutiveLowResults 現ランク下限を下回った連続回数（今回を含まない）
+ */
+export const evaluateRankChange = ({
+  currentRankId,
+  score,
+  confidenceLow,
+  confidenceHigh,
+  consecutiveLowResults = 0,
+}) => {
+  const measured = rankForScore(score);
+  if (!measured) {
+    return { rankId: currentRankId, outcome: 'unmeasured', consecutiveLowResults };
+  }
+
+  const awardable = clampToAwardable(measured.id);
+  const current = getRank(currentRankId);
+
+  // 初回はそのまま付与する
+  if (!current) {
+    return { rankId: awardable, outcome: 'initial', consecutiveLowResults: 0 };
+  }
+
+  const low = Number.isFinite(confidenceLow) ? confidenceLow : score;
+  const high = Number.isFinite(confidenceHigh) ? confidenceHigh : score;
+
+  const next = nextRank(current.id);
+  if (next && !next.locked && low >= next.min) {
+    return { rankId: next.id, outcome: 'promoted', consecutiveLowResults: 0 };
+  }
+
+  if (high < current.min) {
+    const streak = consecutiveLowResults + 1;
+    // 1回の誤差では下げない
+    if (streak >= 2) {
+      const demoted = rankForScore(high);
+      return {
+        rankId: clampToAwardable(demoted ? demoted.id : RANK_IDS[0]),
+        outcome: 'demoted',
+        consecutiveLowResults: 0,
+      };
+    }
+    return { rankId: current.id, outcome: 'held-low', consecutiveLowResults: streak };
+  }
+
+  // 次の境界に手が届いている状態
+  if (next && !next.locked && high >= next.min) {
+    return { rankId: current.id, outcome: 'near-promotion', consecutiveLowResults: 0 };
+  }
+
+  return { rankId: current.id, outcome: 'held', consecutiveLowResults: 0 };
+};
+
+/** 自己ベストは下がっても消さない（計画書8.4）。 */
+export const bestRankOf = (a, b) => {
+  const ia = rankIndex(a);
+  const ib = rankIndex(b);
+  if (ia < 0) return ib < 0 ? null : b;
+  if (ib < 0) return a;
+  return ia >= ib ? a : b;
+};
+
+/**
+ * 移行期間用。既存の level(1〜7) を能力スコアの代表値へ写す。
+ *
+ * 現行テストは自己申告型で、計画書4.1により正式ランク判定には使えない。
+ * ランク表示を先に出すための暫定で、信頼度は low 固定。
+ */
+export const scoreFromLegacyLevel = (level) => {
+  const key = String(level);
+  const score = RANKS.levelToScore[key];
+  return Number.isFinite(score) ? score : null;
+};

--- a/src/logic/rankLogic.test.js
+++ b/src/logic/rankLogic.test.js
@@ -1,0 +1,251 @@
+import {
+  RANK_IDS,
+  bestRankOf,
+  clampToAwardable,
+  evaluateRankChange,
+  getRank,
+  isAwardable,
+  nextRank,
+  pointsToNextRank,
+  progressWithinRank,
+  rankForScore,
+  scoreFromLegacyLevel,
+} from './rankLogic';
+import { buildEquivalency, rankRangeLabel, roundToeic } from './examEquivalency';
+
+describe('ランクの定義', () => {
+  test('E から SS の順に並んでいる', () => {
+    expect(RANK_IDS).toEqual(['E', 'D', 'C', 'B', 'A', 'S', 'SS']);
+  });
+
+  test('境界が隙間なく、重ならずに続いている', () => {
+    for (let i = 1; i < RANK_IDS.length; i += 1) {
+      const prev = getRank(RANK_IDS[i - 1]);
+      const curr = getRank(RANK_IDS[i]);
+      expect(curr.min).toBe(prev.max + 1);
+    }
+  });
+
+  test('0から1000までを覆っている', () => {
+    expect(getRank('E').min).toBe(0);
+    expect(getRank('SS').max).toBe(1000);
+  });
+
+  test('計画書3.2の境界値どおりに分類する', () => {
+    const cases = [
+      [0, 'E'], [149, 'E'], [150, 'D'], [274, 'D'],
+      [275, 'C'], [424, 'C'], [425, 'B'], [574, 'B'],
+      [575, 'A'], [724, 'A'], [725, 'S'], [849, 'S'],
+      [850, 'SS'], [1000, 'SS'],
+    ];
+    for (const [score, expected] of cases) {
+      expect([score, rankForScore(score).id]).toEqual([score, expected]);
+    }
+  });
+
+  test('範囲外のスコアは端に丸める', () => {
+    expect(rankForScore(-50).id).toBe('E');
+    expect(rankForScore(5000).id).toBe('SS');
+  });
+
+  test('数値でなければ未測定', () => {
+    expect(rankForScore(undefined)).toBeNull();
+    expect(rankForScore(null)).toBeNull();
+    expect(rankForScore(NaN)).toBeNull();
+  });
+});
+
+describe('SS のロック', () => {
+  test('SS は正式判定に使えない（C1問題バンク未整備）', () => {
+    expect(isAwardable('SS')).toBe(false);
+    expect(getRank('SS').locked).toBe(true);
+  });
+
+  test('SS 以外はすべて判定に使える', () => {
+    for (const id of ['E', 'D', 'C', 'B', 'A', 'S']) {
+      expect([id, isAwardable(id)]).toEqual([id, true]);
+    }
+  });
+
+  test('SS 相当のスコアでも付与は S までに留める', () => {
+    expect(clampToAwardable('SS')).toBe('S');
+  });
+
+  test('SS の換算は出さない（英検1級相当を根拠なく見せない）', () => {
+    const eq = buildEquivalency({ score: 900 });
+    expect(eq.locked).toBe(true);
+    expect(eq.eiken).toBeNull();
+    expect(eq.toeic).toBeNull();
+  });
+});
+
+describe('次のランクまでの距離', () => {
+  test('計画書3.3の例（518点 → Aまで57）と一致する', () => {
+    expect(rankForScore(518).id).toBe('B');
+    expect(pointsToNextRank(518)).toBe(57);
+  });
+
+  test('境界ちょうどなら0', () => {
+    expect(pointsToNextRank(574)).toBe(1);
+    expect(pointsToNextRank(575)).toBe(150);
+  });
+
+  test('最上位では距離を出さない', () => {
+    expect(pointsToNextRank(900)).toBeNull();
+  });
+
+  test('現ランク内の進み具合は0〜1に収まる', () => {
+    expect(progressWithinRank(425)).toBe(0);
+    expect(progressWithinRank(574)).toBe(1);
+    expect(progressWithinRank(518)).toBeGreaterThan(0.6);
+    expect(progressWithinRank(518)).toBeLessThan(0.7);
+  });
+
+  test('nextRank は最上位で null', () => {
+    expect(nextRank('SS')).toBeNull();
+    expect(nextRank('A').id).toBe('S');
+  });
+});
+
+describe('昇格・維持・降格', () => {
+  test('初回はそのまま付与する', () => {
+    const result = evaluateRankChange({ currentRankId: null, score: 500, confidenceLow: 470, confidenceHigh: 530 });
+    expect(result).toMatchObject({ rankId: 'B', outcome: 'initial' });
+  });
+
+  test('昇格は信頼区間の下限が次の境界を超えたときだけ', () => {
+    // 点推定は A 帯だが、下限が B 帯 → 上げない
+    const held = evaluateRankChange({ currentRankId: 'B', score: 580, confidenceLow: 540, confidenceHigh: 620 });
+    expect(held.outcome).toBe('near-promotion');
+    expect(held.rankId).toBe('B');
+
+    const promoted = evaluateRankChange({ currentRankId: 'B', score: 620, confidenceLow: 580, confidenceHigh: 660 });
+    expect(promoted).toMatchObject({ rankId: 'A', outcome: 'promoted' });
+  });
+
+  test('1回下振れしただけでは降格しない', () => {
+    const first = evaluateRankChange({ currentRankId: 'B', score: 400, confidenceLow: 370, confidenceHigh: 420 });
+    expect(first).toMatchObject({ rankId: 'B', outcome: 'held-low', consecutiveLowResults: 1 });
+  });
+
+  test('2回続けて下回ったら降格する', () => {
+    const second = evaluateRankChange({
+      currentRankId: 'B', score: 400, confidenceLow: 370, confidenceHigh: 420, consecutiveLowResults: 1,
+    });
+    expect(second).toMatchObject({ rankId: 'C', outcome: 'demoted', consecutiveLowResults: 0 });
+  });
+
+  test('SS へは昇格させない', () => {
+    const result = evaluateRankChange({ currentRankId: 'S', score: 900, confidenceLow: 880, confidenceHigh: 950 });
+    expect(result.rankId).toBe('S');
+    expect(result.outcome).not.toBe('promoted');
+  });
+
+  test('信頼区間が無ければ点推定で代用する', () => {
+    const result = evaluateRankChange({ currentRankId: 'B', score: 620 });
+    expect(result).toMatchObject({ rankId: 'A', outcome: 'promoted' });
+  });
+});
+
+describe('自己ベスト', () => {
+  test('下がっても自己ベストは残る', () => {
+    expect(bestRankOf('A', 'C')).toBe('A');
+    expect(bestRankOf('C', 'A')).toBe('A');
+  });
+
+  test('片方が未設定なら他方', () => {
+    expect(bestRankOf(null, 'B')).toBe('B');
+    expect(bestRankOf('B', null)).toBe('B');
+    expect(bestRankOf(null, null)).toBeNull();
+  });
+});
+
+describe('英検・TOEIC の参考換算', () => {
+  test('TOEIC は5点刻みで丸める', () => {
+    expect(roundToeic(387)).toBe(385);
+    expect(roundToeic(383)).toBe(385);
+    expect(roundToeic(548)).toBe(550);
+  });
+
+  test('計画書3.3の例と同じ文言になる', () => {
+    const eq = buildEquivalency({ score: 518 });
+    expect(eq.eiken).toBe('英検準2級〜準2級プラス相当の目安');
+    expect(eq.toeic.label).toBe('TOEIC L&R 385〜545点の参考レンジ');
+  });
+
+  test('断定表現を作らない', () => {
+    for (const id of ['E', 'D', 'C', 'B', 'A', 'S']) {
+      const rank = getRank(id);
+      const eq = buildEquivalency({ score: rank.min });
+      expect(eq.eiken).toMatch(/相当の目安$/);
+      expect(eq.toeic.label).toMatch(/参考レンジ$/);
+      expect(eq.eiken).not.toMatch(/合格|公式認定/);
+    }
+  });
+
+  test('注記と換算表のバージョンが常に付く', () => {
+    const eq = buildEquivalency({ score: 300 });
+    expect(eq.disclaimer).toMatch(/保証するものではありません/);
+    expect(eq.tableVersion).toBeGreaterThan(0);
+  });
+
+  test('測っていない技能を明示する', () => {
+    expect(buildEquivalency({ score: 300 }).notMeasured).toEqual(['Speaking', 'Writing']);
+  });
+
+  test('未測定なら換算も出さない', () => {
+    expect(buildEquivalency({ score: undefined })).toBeNull();
+  });
+});
+
+describe('信頼区間がまたぐときの表示', () => {
+  test('区間が同じランク内なら断定する', () => {
+    expect(rankRangeLabel({ score: 500, confidenceLow: 480, confidenceHigh: 540 })).toBe('B');
+  });
+
+  test('区間が境界をまたぐなら範囲で示す', () => {
+    expect(rankRangeLabel({ score: 570, confidenceLow: 540, confidenceHigh: 600 })).toBe('B〜A');
+  });
+
+  test('未測定は未測定', () => {
+    expect(rankRangeLabel({ score: null })).toBe('未測定');
+  });
+});
+
+describe('移行期間の level → スコア', () => {
+  test('現行の1〜7がすべて写せる', () => {
+    for (let level = 1; level <= 7; level += 1) {
+      expect([level, Number.isFinite(scoreFromLegacyLevel(level))]).toEqual([level, true]);
+    }
+  });
+
+  test('レベルが上がるほどスコアも上がる', () => {
+    const scores = [1, 2, 3, 4, 5, 6, 7].map(scoreFromLegacyLevel);
+    expect(scores).toEqual([...scores].sort((a, b) => a - b));
+  });
+
+  test('現行の最高レベル7は S 止まりで、SS にはならない', () => {
+    // levels.json のレベル7は CEFR B2 / 英検準1級。ランクSの定義と一致する。
+    // 既存Lv.7を名前だけSSにして英検1級相当と表示しない（計画書2.3）。
+    expect(rankForScore(scoreFromLegacyLevel(7)).id).toBe('S');
+    expect(rankForScore(scoreFromLegacyLevel(7)).id).not.toBe('SS');
+  });
+
+  test('level のCEFRとランクのCEFRが食い違わない', () => {
+    const LEVELS = require('../config/levels.json');
+    const pairs = LEVELS.map((entry) => [
+      entry.cefr,
+      rankForScore(scoreFromLegacyLevel(entry.level)).cefr,
+    ]);
+    // A2 は C/B に、B1 は B/A に分かれるので前方一致で確認する
+    for (const [levelCefr, rankCefr] of pairs) {
+      const head = levelCefr.split('-')[0];
+      expect([levelCefr, rankCefr.startsWith(head)]).toEqual([levelCefr, true]);
+    }
+  });
+
+  test('未測定(0)は写さない', () => {
+    expect(scoreFromLegacyLevel(0)).toBeNull();
+    expect(scoreFromLegacyLevel(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
`ASSESSMENT_RANK_SYSTEM_PLAN.md` のフェーズ1と、フェーズ7のうち評価エンジンに依存しない部分。

## 実装した範囲

- **`src/config/ranks.json`** — 計画書3.2の初期換算テーブル（E〜SS、CEFR・英検・TOEICレンジ）
- **`src/logic/rankLogic.js`** — スコア→ランク、次ランクまでの距離、信頼区間を使った昇格・維持・降格、自己ベスト
  - 昇格は**信頼区間の下限**が次の境界を超えたときだけ。点推定だけだと1回の当たりで上がって次に下がる
  - 降格は上限が現ランク下限を下回る結果が**2回続いた**ときだけ
- **`src/logic/examEquivalency.js`** — CEFR経由の暫定換算。「相当の目安」「参考レンジ」に固定し断定表現を作らない。TOEICは5点刻み。注記・信頼度・換算表バージョンを必ず添える
- **SS はロック** — C1問題バンクが無いので正式判定しない。スコアが届いても付与はSまで、換算も出さない（計画書2.3）
- **`RankBadge` / `RankCard`** — 基準5色のまま、枠・二重線・光沢・縁光だけでランク差を表現（計画書8.3）。新しい色は足していない

## 移行期間の扱い

現行テストは自己申告型で計画書4.1により正式ランク判定に使えないため、既存 `level(1〜7)` を代表スコアへ写して**表示だけ**行う。`levels.json` のレベル7は CEFR B2 / 英検準1級で、ランクSの定義と一致する。名前だけSSにして英検1級相当と表示することはしない。

ホームの `LevelBadge` をランクカードへ置き換え。1画面に収まることを本番で確認（はみ出し 115px → 0）。

## 着手していない範囲と理由

フェーズ2〜6は**問題バンクという中身**が前提です。5領域×7ランクの4択問題、Listening用の音声、作成者と別の確認者、識別力を出すための実受験データ。フェーズ5は生徒本人の同意付き公式スコアの収集が要ります。コードだけで用意できるものではないため着手していません。

テスト37件追加、256件パス。lint クリーン。基準色の検査も通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)